### PR TITLE
feat: 일부 UI 수정

### DIFF
--- a/src/components/combination/CombinationProductCard.tsx
+++ b/src/components/combination/CombinationProductCard.tsx
@@ -1,3 +1,7 @@
+import { useState } from "react";
+import boxIcon from "../../assets/box.png";
+import checkboxIcon from "../../assets/check box.png";
+
 interface Props {
   item: {
     name: string;
@@ -12,26 +16,40 @@ export default function CombinationProductCard({
   isSelected,
   onToggle,
 }: Props) {
+  const [checkedMobile, setCheckedMobile] = useState(false);
+
+  const handleMobileToggle = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 카드 클릭 막기
+    setCheckedMobile((prev) => !prev);
+    onToggle();
+  };
+
   return (
     <div
-      onClick={onToggle}
-      className={`relative cursor-pointer box-border
-        ${isSelected ? "bg-[#EEEEEE]" : "bg-white"}
+      className={`relative cursor-default box-border
+        ${checkedMobile ? "bg-[#EFEFEF]" : isSelected ? "bg-[#EEEEEE]" : "bg-white"}
 
         // 모바일
         w-[156px] h-[156px] pt-[34px] pr-[17px] pb-[14px] pl-[17px] rounded-[13px]
         shadow-[2px_3px_12.4px_0px_rgba(0,0,0,0.16)]
 
         // PC
-        md:w-[299px] md:h-[246px] md:pt-[15px] md:pr-[24px] md:pb-[15px] md:pl-[24px] md:rounded-[25px]
-        md:shadow-md md:hover:shadow-lg
+        md:w-[299px] md:h-[246px] md:p-[24px] md:rounded-[25px]
+        md:shadow-[2px_3px_12.4px_0px_rgba(0,0,0,0.16)] 
+        md:hover:shadow-lg
       `}
     >
       <img
+        src={checkedMobile ? checkboxIcon : boxIcon}
+        alt="check"
+        onClick={handleMobileToggle}
+        className="absolute top-[12px] left-[12px] w-[30px] h-[30px] md:hidden cursor-pointer"
+      />
+
+      <img
         src={item.imageUrl}
-        alt={item.name}
-        className="mx-auto mb-auto object-contain
-          w-[64px] h-[64px] md:w-[150px] md:h-[150px]"
+        className="mx-auto object-contain
+        w-[80px] h-[80px] md:w-[150px] md:h-[150px]"
       />
 
       <div
@@ -48,7 +66,7 @@ export default function CombinationProductCard({
           e.stopPropagation();
           onToggle();
         }}
-        className="hidden md:block absolute text-[22px] text-[#1C1B1F]"
+        className="hidden md:block absolute text-[40px] text-[#1C1B1F]"
         style={{
           top: "26.57px",
           left: "237.45px",

--- a/src/components/combination/ExpandableProductGroup.tsx
+++ b/src/components/combination/ExpandableProductGroup.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import CombinationProductCard from "./CombinationProductCard";
-import { FiChevronDown, FiChevronUp } from "react-icons/fi";
+import { FiChevronDown } from "react-icons/fi";
 
 interface Product {
   name: string;
@@ -43,24 +43,20 @@ const ExpandableProductGroup = ({
       </div>
 
       {/* 펼쳐보기 섹션 */}
-      {products.length > 2 && (
+      {!expanded && products.length > 2 && (
         <div className="mt-4 w-full">
           <div
             className="flex justify-center items-center cursor-pointer"
-            onClick={() => setExpanded((prev) => !prev)}
+            onClick={() => setExpanded(true)}
           >
             <span
               className="text-[12px] font-medium leading-[120%] tracking-[-0.02em] text-center font-pretendard text-black"
               style={{ width: "50px", height: "14px" }}
             >
-              {expanded ? "접기" : "펼쳐보기"}
+              펼쳐보기
             </span>
             <span className="ml-1" style={{ marginTop: "3px" }}>
-              {expanded ? (
-                <FiChevronUp size={16} color="#1C1B1F" />
-              ) : (
-                <FiChevronDown size={16} color="#1C1B1F" />
-              )}
+              <FiChevronDown size={16} color="#1C1B1F" />
             </span>
           </div>
 

--- a/src/pages/combination/AddCombinationPage.tsx
+++ b/src/pages/combination/AddCombinationPage.tsx
@@ -89,15 +89,15 @@ const AddCombinationPage = () => {
   );
 
   return (
-    <div className="w-full bg-[#FFFFFF] md:bg-[#FAFAFA] px-0 md:px-4 py-0 font-pretendard">
+    <div className="min-h-screen w-full bg-[#FFFFFF] md:bg-[#FAFAFA] px-0 md:px-4 py-0 font-pretendard flex flex-col pb-[280px]">
       {/* 조합추가 - 모바일 버전 */}
       <h1 className="block md:hidden font-Pretendard font-bold text-[32px] leading-[100%] tracking-[-0.02em] mb-5 px-10 pt-10">
-        조합추가
+        조합 추가
       </h1>
 
       {/* 조합추가 - PC 버전 */}
       <h1 className="hidden md:block font-pretendard font-bold text-[52px] leading-[120%] tracking-[-0.02em] mb-8 px-[230px] pt-[50px]">
-        조합추가
+        조합 추가
       </h1>
 
       {/* 검색창 - 모바일 */}
@@ -127,16 +127,16 @@ const AddCombinationPage = () => {
       </div>
 
       {/* 검색창 - PC */}
-      <div className="hidden md:flex justify-center mb-8">
+      <div className="hidden md:flex justify-center mb-3">
         <div className="w-[1400px] h-[85px] bg-transparent border border-[#C7C7C7] rounded-[88px] flex items-center px-[35.64px] gap-[165px]">
           <input
             type="text"
             className="flex-1 h-full bg-transparent outline-none
-            placeholder:font-pretendard placeholder:font-medium
-            placeholder:text-black placeholder:opacity-40
-            placeholder:leading-[30px] placeholder:tracking-[-0.02em]
-            placeholder:text-[30px] 
-            text-[30px] leading-[30px]"
+        placeholder:font-Pretendard placeholder:font-medium
+        placeholder:text-black placeholder:opacity-40
+        placeholder:leading-[30px] placeholder:tracking-[-0.02em]
+        placeholder:text-[30px] 
+        text-[30px] leading-[30px]"
             placeholder={placeholder}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
@@ -154,7 +154,7 @@ const AddCombinationPage = () => {
       {searchHistory.length > 0 && (
         <div className="block md:hidden mb-12 flex justify-center">
           <div
-            className="flex flex-wrap justify-center items-center gap-x-2 gap-y-2 text-[14px]"
+            className="flex flex-wrap justify-center items-center gap-x-8 gap-y-2 text-[14px]"
             style={{ width: "300px", height: "auto", opacity: 1 }}
           >
             {searchHistory.map((item, idx) => (
@@ -186,27 +186,30 @@ const AddCombinationPage = () => {
 
       {/* 검색 기록 - PC */}
       {searchHistory.length > 0 && (
-        <div className="hidden md:flex justify-center gap-6 text-xl text-gray-700 mb-12 flex-wrap px-[35.64px]">
+        <div className="hidden md:flex justify-center gap-[24px] flex-wrap px-[35.64px] mb-5">
           {searchHistory.map((item, idx) => (
-            <div key={idx} className="flex items-center gap-2 px-10 py-2">
+            <div key={idx} className="flex items-center gap-2 px-8 py-2">
               <button
                 onClick={() => {
                   setSearchTerm(item);
-                  setQuery(item);
                   navigate(
                     `/add-combination?query=${encodeURIComponent(item)}`
                   );
                 }}
-                className="hover:underline"
+                className="text-[20px] font-medium leading-[120%] tracking-[-0.02em] text-[#000000] hover:underline"
               >
                 {item}
               </button>
               <button
                 onClick={() => handleDelete(item)}
-                className="hover:text-[#555555] ml-2"
+                className="text-[16px] text-[#8A8A8A]"
                 title="삭제"
               >
-                <FiX className="text-[#8A8A8A] text-[18px]" />
+                <img
+                  src="/src/assets/delete.png"
+                  alt="삭제 아이콘"
+                  className="w-[28px] h-[28px] mt-[2.5px]"
+                />
               </button>
             </div>
           ))}
@@ -220,12 +223,12 @@ const AddCombinationPage = () => {
             <>
               {/* 검색어 제목 - 모바일 */}
               <h2 className="block md:hidden font-pretendard font-bold text-[22px] leading-[120%] tracking-[-0.02em] px-[38px] mb-6">
-                # {query}
+                {query}
               </h2>
 
               {/* 검색어 제목 - PC */}
-              <h2 className="hidden md:block font-pretendard font-bold text-[40px] leading-[120%] tracking-[-0.02em] mb-8 px-[230px] pt-[50px]">
-                # {query}
+              <h2 className="hidden md:block font-pretendard font-bold text-[40px] leading-[120%] tracking-[-0.02em] mb-8 px-[230px] pt-[10px]">
+                {query}
               </h2>
             </>
           )}
@@ -244,15 +247,19 @@ const AddCombinationPage = () => {
               </div>
 
               {/* PC 카드 */}
-              <div className="hidden md:grid w-[1000px] h-[1300px] mt-[50px] ml-[240px] gap-[40px] grid-cols-3">
-                {filteredProducts.map((item, idx) => (
-                  <CombinationProductCard
-                    key={idx}
-                    item={item}
-                    isSelected={selectedItems.some((i) => i.name === item.name)}
-                    onToggle={() => handleToggle(item)}
-                  />
-                ))}
+              <div className="hidden md:flex px-[230px] mt-[50px] mb-[60px] gap-[60px]">
+                <div className="grid grid-cols-3 gap-[40px] w-[980px]">
+                  {filteredProducts.map((item, idx) => (
+                    <CombinationProductCard
+                      key={idx}
+                      item={item}
+                      isSelected={selectedItems.some(
+                        (i) => i.name === item.name
+                      )}
+                      onToggle={() => handleToggle(item)}
+                    />
+                  ))}
+                </div>
               </div>
             </>
           ) : (
@@ -285,66 +292,48 @@ const AddCombinationPage = () => {
               }}
             >
               {/* 분석 시작 버튼 */}
-              <button
-                onClick={() =>
-                  navigate("/combination-result", {
-                    state: { selectedItems }, // 선택된 제품 배열
-                  })
-                }
-                className="w-[314px] h-[80px] bg-[#FFEB9D] rounded-[59px] text-[30px] font-semibold font-pretendard leading-[120%] tracking-[-0.02em] text-center px-[90px] mt-[50px] mb-[30px]"
-              >
-                분석 시작
-              </button>
-
-              {selectedItems.length > 0 && (
-                <div
-                  className="flex flex-col items-center"
-                  style={{
-                    width: "314px",
-                    backgroundColor: "#F2F2F2",
-                    border: "0.8px solid #9C9A9A",
-                    borderRadius: "36px",
-                    paddingTop: "33px",
-                    paddingRight: "34px",
-                    paddingBottom: "33px",
-                    paddingLeft: "34px",
-                    boxSizing: "border-box",
-                    height: "fit-content",
-                  }}
+              <div className="w-[314px] flex-shrink-0">
+                <button
+                  onClick={() =>
+                    navigate("/combination-result", {
+                      state: { selectedItems },
+                    })
+                  }
+                  className="w-full h-[80px] bg-[#FFEB9D] rounded-[59px] text-[30px] font-semibold font-pretendard leading-[120%] tracking-[-0.02em] text-center mt-[10px] mb-[30px]"
                 >
-                  <div className="w-full flex justify-between items-center"></div>
+                  분석 시작
+                </button>
 
-                  {/* 선택된 제품 카드 리스트 */}
-                  <div className="flex flex-col items-center gap-4 w-full">
+                {selectedItems.length > 0 && (
+                  <div className="bg-[#F2F2F2] border border-[#9C9A9A] rounded-[36px] px-[34px] py-[33px] flex flex-col gap-10">
                     {selectedItems.map((item, idx) => (
                       <div
                         key={idx}
-                        className="relative w-[230px] h-[250px] bg-white border border-gray-200 rounded-[30px] flex flex-col items-center justify-center px-4 py-6 shadow"
+                        className="relative w-full h-[250px] bg-white border border-gray-200 rounded-[30px] flex flex-col items-center justify-center px-4 py-6 shadow"
                       >
-                        {/* X 버튼 */}
                         <button
                           onClick={() => handleRemove(item.name)}
-                          className="absolute top-3 right-4 text-gray-400 text-2xl"
+                          className="absolute top-3 right-4"
                         >
-                          ×
+                          <img
+                            src="/src/assets/delete.png"
+                            alt="삭제"
+                            className="w-[40px] h-[40px]"
+                          />
                         </button>
 
-                        {/* 제품 이미지 */}
                         <img
                           src={item.imageUrl}
-                          alt={item.name}
                           className="w-[120px] h-[120px] object-contain mb-4"
                         />
-
-                        {/* 제품 이름 */}
                         <p className="text-sm text-center font-medium leading-tight">
                           {item.name}
                         </p>
                       </div>
                     ))}
                   </div>
-                </div>
-              )}
+                )}
+              </div>
             </div>
 
             {/* 모바일 분석 목록 */}
@@ -354,15 +343,14 @@ const AddCombinationPage = () => {
                 boxShadow: "0px -22px 40px 0px #C1C1C140",
                 paddingTop: "18px",
                 paddingRight: "10px",
-                paddingBottom: "max(30px, env(safe-area-inset-bottom))",
+                paddingBottom: "max(20px, env(safe-area-inset-bottom))",
                 paddingLeft: "10px",
                 maxHeight: "280px",
-                overflowY: "auto",
                 boxSizing: "border-box",
               }}
             >
               {/* 상단: 제목 & 시작 버튼 */}
-              <div className="flex justify-between items-center mb-2">
+              <div className="flex justify-between items-center mb-3">
                 <h3 className="font-pretendard font-bold text-[22px] leading-[120%] tracking-[-0.02em] px-3">
                   분석 목록
                 </h3>
@@ -372,37 +360,25 @@ const AddCombinationPage = () => {
                       state: { selectedItems },
                     })
                   }
-                  className="bg-[#FFEB9D] rounded-[20px] flex items-center justify-center"
-                  style={{
-                    width: "67px",
-                    height: "32px",
-                    padding: "12px 18px",
-                  }}
+                  className="bg-transparent p-0 border-none" // 버튼 배경 제거 및 여백 제거
                 >
-                  <span
-                    className="font-pretendard"
-                    style={{
-                      fontWeight: 500,
-                      fontSize: "15px",
-                      lineHeight: "120%",
-                      letterSpacing: "-0.02em",
-                      textAlign: "center",
-                    }}
-                  >
-                    시작
-                  </span>
+                  <img
+                    src="/src/assets/시작.png"
+                    alt="분석 시작"
+                    className="w-[67px] h-[32px] mr-1 object-contain"
+                  />
                 </button>
               </div>
 
               {/* 설명 텍스트 */}
-              <p className="text-[14px] font-medium leading-[120%] tracking-[-0.02em] text-[#808080] mb-3 font-pretendard px-3">
+              <p className="text-[14px] font-medium leading-[120%] tracking-[-0.02em] text-[#808080] mb-5 font-pretendard px-3">
                 최대 10개 선택
               </p>
 
               {/* 전체 감싸는 외곽 카드 */}
               <div
-                className="w-full rounded-[22px] border border-[#B2B2B2] bg-white overflow-x-auto px-4 py-3"
-                style={{ height: "156px" }}
+                className="w-full max-w-[600px] mx-auto rounded-[25px] border border-[#B2B2B2] bg-white overflow-x-auto hide-scrollbar"
+                style={{ height: "160px" }}
               >
                 <div className="flex gap-[10px] w-max">
                   {selectedItems.map((item, idx) => (
@@ -410,21 +386,26 @@ const AddCombinationPage = () => {
                       key={idx}
                       className="relative w-[130px] h-[130px] bg-white rounded-[10px] flex-shrink-0 flex flex-col items-center"
                       style={{
-                        paddingTop: "26px",
+                        paddingTop: "22px",
                         paddingBottom: "12px",
                       }}
                     >
                       <img
                         src={item.imageUrl}
-                        alt={item.name}
-                        className="w-[70px] h-[50px] object-contain mb-2"
+                        className="w-[80px] h-[85px] object-contain mb-3"
                       />
-                      <p className="text-xs text-center px-1">{item.name}</p>
+                      <p className="text-[12px] font-medium leading-[100%] tracking-[-0.02em] text-center font-pretendard text-black px-1">
+                        {item.name}
+                      </p>
                       <button
                         onClick={() => handleRemove(item.name)}
-                        className="absolute top-1 right-1 text-lg text-gray-400"
+                        className="absolute bottom-25 right-1"
                       >
-                        ×
+                        <img
+                          src="/src/assets/delete.png"
+                          alt="삭제"
+                          className="w-[27px] h-[27px]"
+                        />
                       </button>
                     </div>
                   ))}

--- a/src/pages/combination/CombinationPage.tsx
+++ b/src/pages/combination/CombinationPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Cat from "../../assets/CatWithPointer.png";
 import Chick from "../../assets/chick.png";
+import flipIcon from "../../assets/flip.png";
 import { FiSearch, FiX } from "react-icons/fi";
 
 const CombinationPage = () => {
@@ -16,6 +17,22 @@ const CombinationPage = () => {
       setSearchHistory(JSON.parse(savedHistory));
     }
   }, []);
+
+  const riskyCombinations = [
+    "철분 + 칼슘",
+    "아연 + 철분",
+    "아연 + 구리",
+    "비타민C + 철분",
+    "칼슘 + 마그네슘",
+  ];
+
+  const goodCombinations = [
+    "비타민D + 칼슘",
+    "철분 + 비타민C",
+    "마그네슘 + 비타민B6",
+    "유산균 + 아연",
+    "오메가3 + 비타민E",
+  ];
 
   const handleSearch = () => {
     const trimmed = searchTerm.trim();
@@ -38,20 +55,19 @@ const CombinationPage = () => {
   };
 
   return (
-    <div className="w-full bg-[#FFFFFF] md:bg-[#FAFAFA] px-0 md:px-4 py-0 font-pretendard">
+    <div className="min-h-screen w-full bg-[#FFFFFF] md:bg-[#FAFAFA] px-0 md:px-4 py-0 font-pretendard flex flex-col">
+      {" "}
       {/* 조합추가 - 모바일 버전 */}
       <h1 className="block md:hidden font-Pretendard font-bold text-[32px] leading-[100%] tracking-[-0.02em] mb-5 px-10 pt-10">
-        조합추가
+        조합 추가
       </h1>
-
       {/* 조합추가 - PC 버전 */}
-      <h1 className="hidden md:block font-Pretendard font-bold text-[52px] leading-[120%] tracking-[-0.02em] mb-8 px-[230px] pt-[50px]">
-        조합추가
+      <h1 className="hidden md:block font-pretendard font-bold text-[52px] leading-[120%] tracking-[-0.02em] mb-8 px-[230px] pt-[50px]">
+        조합 추가
       </h1>
-
       {/* 검색창 - 모바일 */}
       <div className="flex justify-center mb-4 md:hidden">
-        <div className="w-[366px] h-[52px] bg-[#f2f2f2] border border-[#C7C7C7] rounded-[44px] flex items-center px-[18px] gap-[84px] shadow-inner">
+        <div className="w-[366px] h-[52px] bg-white border border-[#C7C7C7] rounded-[44px] flex items-center px-[18px] gap-[84px]">
           <input
             type="text"
             className="flex-1 h-full bg-transparent outline-none
@@ -71,9 +87,8 @@ const CombinationPage = () => {
           </button>
         </div>
       </div>
-
       {/* 검색창 - PC */}
-      <div className="hidden md:flex justify-center mb-8">
+      <div className="hidden md:flex justify-center mb-3">
         <div className="w-[1400px] h-[85px] bg-transparent border border-[#C7C7C7] rounded-[88px] flex items-center px-[35.64px] gap-[165px]">
           <input
             type="text"
@@ -95,12 +110,11 @@ const CombinationPage = () => {
           </button>
         </div>
       </div>
-
       {/* 검색 기록 - 모바일 */}
       {searchHistory.length > 0 && (
-        <div className="block md:hidden mb-12 flex justify-center">
+        <div className="block md:hidden flex justify-center">
           <div
-            className="flex flex-wrap justify-center items-center gap-x-2 gap-y-2 text-[14px]"
+            className="flex flex-wrap justify-center items-center gap-x-8 gap-y-2 text-[14px]"
             style={{ width: "300px", height: "auto", opacity: 1 }}
           >
             {searchHistory.map((item, idx) => (
@@ -121,19 +135,22 @@ const CombinationPage = () => {
                   className="text-[16px] text-[#8A8A8A]"
                   title="삭제"
                 >
-                  <FiX />
+                  <img
+                    src="/src/assets/delete.png"
+                    alt="삭제 아이콘"
+                    className="w-[16px] h-[16px]"
+                  />
                 </button>
               </div>
             ))}
           </div>
         </div>
       )}
-
       {/* 검색 기록 - PC */}
       {searchHistory.length > 0 && (
-        <div className="hidden md:flex justify-center gap-6 text-xl text-gray-700 mb-12 flex-wrap px-[35.64px]">
+        <div className="hidden md:flex justify-center gap-[24px] flex-wrap px-[35.64px] mb-5">
           {searchHistory.map((item, idx) => (
-            <div key={idx} className="flex items-center gap-2 px-10 py-2">
+            <div key={idx} className="flex items-center gap-2 px-8 py-2">
               <button
                 onClick={() => {
                   setSearchTerm(item);
@@ -141,22 +158,25 @@ const CombinationPage = () => {
                     `/add-combination?query=${encodeURIComponent(item)}`
                   );
                 }}
-                className="hover:underline"
+                className="text-[20px] font-medium leading-[120%] tracking-[-0.02em] text-[#000000] hover:underline"
               >
                 {item}
               </button>
               <button
                 onClick={() => handleDelete(item)}
-                className="hover:text-[#555555] ml-2"
+                className="text-[16px] text-[#8A8A8A]"
                 title="삭제"
               >
-                <FiX className="text-[#8A8A8A] text-[18px]" />
+                <img
+                  src="/src/assets/delete.png"
+                  alt="삭제 아이콘"
+                  className="w-[28px] h-[28px] mt-[2.5px]"
+                />
               </button>
             </div>
           ))}
         </div>
       )}
-
       {/* 고양이 일러스트 + 설명 - 모바일 */}
       <div className="relative flex justify-center my-20 md:hidden">
         <div className="relative w-[200px]">
@@ -196,9 +216,8 @@ const CombinationPage = () => {
           </p>
         </div>
       </div>
-
       {/* 고양이 일러스트 + 설명 - PC */}
-      <div className="relative flex justify-center my-16 hidden md:flex">
+      <div className="relative flex justify-center my-14 hidden md:flex">
         <div className="relative w-[200px]">
           {/* 왼쪽 텍스트 */}
           <p
@@ -235,130 +254,171 @@ const CombinationPage = () => {
           </p>
         </div>
       </div>
-
       {/* 구분선 */}
       <div>
         {/* 모바일: 고정 너비 */}
-        <div className="block md:hidden w-[390px] h-[0.5px] bg-[#B2B2B2] mx-auto my-8" />
+        <div className="block md:hidden w-[390px] h-[0.5px] bg-[#B2B2B2] mx-auto" />
         {/* PC: 가로 길이 자동 확장 */}
         <div className="hidden md:block w-[1400px] h-[0.5px] bg-[#B2B2B2] mx-auto my-8" />
       </div>
-
-      {/* 주의 조합 */}
-      <div className="mt-10 mb-10 max-w-[1400px] mx-auto">
-        {/* 제목 */}
-        {/* 모바일용 제목 */}
-        <h2 className="block md:hidden w-[366px] px-[18px] h-[26px] text-[22px] font-semibold font-Pretendard leading-[120%] tracking-[-0.02em] text-black mb-6">
+      {/* 주의가 필요한 조합 안내 - 모바일 */}
+      <div className="md:hidden px-7 mt-8">
+        <h2
+          style={{
+            width: "390px",
+            height: "26px",
+            fontFamily: "Pretendard",
+            fontWeight: 600,
+            fontSize: "22px",
+            lineHeight: "120%",
+            letterSpacing: "-0.02em",
+            color: "#000000",
+          }}
+        >
           주의가 필요한 조합 TOP 5
         </h2>
-        {/* 모바일 카드 */}
-        <div className="md:hidden overflow-x-auto px-[18px]">
-          <div className="flex gap-[17px] w-fit">
-            {[
-              "철분 + 칼슘",
-              "아연 + 철분",
-              "아연 + 구리",
-              "비타민C + 철분",
-              "칼슘 + 마그네슘",
-            ].map((combo, i) => (
-              <div
-                key={i}
-                className="w-[130px] h-[114px] rounded-[14px] px-[6px] py-[10px] 
-          bg-white text-[16px] font-normal flex items-center justify-center 
-          text-center shadow-[2px_2px_12.2px_0px_#00000040]"
-              >
-                {combo}
-                <span className="absolute top-[10px] right-[10px] w-[18px] h-[18px] text-[#414141] rotate-90 text-[18px] flex items-center justify-center">
-                  ⟳
-                </span>
-              </div>
-            ))}
-          </div>
+        <p
+          style={{
+            width: "200px",
+            height: "17px",
+            fontFamily: "Pretendard",
+            fontWeight: 600,
+            fontSize: "14px",
+            lineHeight: "120%",
+            letterSpacing: "-0.02em",
+            color: "#6B6B6B",
+            marginTop: "6px",
+          }}
+        >
+          카드를 눌러서 확인해 보세요 !
+        </p>
+      </div>
+      {/* 조합 카드들 - 모바일 */}
+      <div className="md:hidden px-3 hide-scrollbar overflow-x-auto">
+        <div className="w-max flex gap-[16px] ml-4 mr-4 mb-5 mt-5">
+          {riskyCombinations.map((combo, i) => (
+            <div
+              key={i}
+              className="w-[130px] h-[114px] bg-white rounded-[14px] shadow-[2px_2px_12.2px_0px_#00000040] px-[6px] py-[10px] text-center text-[16px] font-medium flex items-center justify-center relative"
+            >
+              {combo}
+              <img
+                src={flipIcon}
+                alt="회전 아이콘"
+                className="absolute top-[10px] right-[10px] w-[20px] h-[20px] opacity-100"
+              />
+            </div>
+          ))}
         </div>
-        {/* PC용 제목 */}
-        <h2 className="hidden md:block w-[1400px] px-[35.64px] h-[38px] text-[32px] font-bold font-Pretendard leading-[120%] tracking-[-0.02em] text-black mb-6">
+      </div>
+      {/* PC용 제목 및 카드 wrapper */}
+      <div className="hidden md:block px-[230px]">
+        <h2 className="hidden md:block w-[1500px] h-[38px] text-[32px] font-bold font-Pretendard leading-[120%] tracking-[-0.02em] text-black mb-10 mt-3">
           주의가 필요한 조합 TOP 5
+          <span className="ml-8 text-[22px] font-semibold font-Pretendard leading-[120%] tracking-[-0.02em] text-[#6B6B6B]">
+            카드를 눌러서 확인해 보세요 !
+          </span>
         </h2>
+
         {/* PC 카드 */}
-        <div className="hidden md:flex justify-center">
+        <div className="flex justify-start">
           <div className="flex gap-[50px]">
-            {[
-              "철분 + 칼슘",
-              "아연 + 철분",
-              "아연 + 구리",
-              "비타민C + 철분",
-              "칼슘 + 마그네슘",
-            ].map((combo, i) => (
+            {riskyCombinations.map((combo, i) => (
               <div
                 key={i}
                 className="w-[224px] h-[170px] rounded-[14px] px-[6px] py-[10px] 
-          bg-white text-[25px] font-normal flex items-center justify-center 
-          text-center shadow-[2px_2px_12.2px_0px_#00000040] relative"
+bg-white flex items-center justify-center 
+shadow-[2px_2px_12.2px_0px_#00000040] relative"
               >
-                {combo}
-                <span className="absolute top-[10px] right-[10px] w-[18px] h-[18px] text-[#414141] rotate-90 text-[18px] flex items-center justify-center">
-                  ⟳
+                <span className="w-[200px] h-[36px] font-pretendard font-medium text-[25px] leading-[100%] tracking-[0] text-[#414141] text-center">
+                  {combo}
+                  <img
+                    src={flipIcon}
+                    alt="회전 아이콘"
+                    className="absolute top-[10px] right-[10px] w-[25px] h-[25px] opacity-100"
+                  />
                 </span>
               </div>
             ))}
           </div>
         </div>
       </div>
-
-      {/* 좋은 조합 */}
-      <div className="mb-10 max-w-[1400px] mx-auto">
-        {/* 제목 */}
-        {/* 모바일용 제목 */}
-        <h2 className="block md:hidden w-[366px] px-[18px] h-[26px] text-[22px] font-semibold font-Pretendard leading-[120%] tracking-[-0.02em] text-black mb-6">
+      {/* ===== 모바일 - 궁합이 좋은 조합 안내 ===== */}
+      <div className="md:hidden px-7 mt-10">
+        <h2
+          style={{
+            width: "390px",
+            height: "26px",
+            fontFamily: "Pretendard",
+            fontWeight: 600,
+            fontSize: "22px",
+            lineHeight: "120%",
+            letterSpacing: "-0.02em",
+            color: "#000000",
+          }}
+        >
           궁합이 좋은 조합 TOP 5
         </h2>
-        {/* 모바일 카드 */}
-        <div className="md:hidden overflow-x-auto px-[18px]">
-          <div className="flex gap-[17px] w-fit">
-            {[
-              "철분 + 칼슘",
-              "아연 + 철분",
-              "아연 + 구리",
-              "비타민C + 철분",
-              "칼슘 + 마그네슘",
-            ].map((combo, i) => (
-              <div
-                key={i}
-                className="w-[130px] h-[114px] rounded-[14px] px-[6px] py-[10px] 
-          bg-white text-[16px] font-normal flex items-center justify-center 
-          text-center shadow-[2px_2px_12.2px_0px_#00000040]"
-              >
-                {combo}
-                <span className="absolute top-[10px] right-[10px] w-[18px] h-[18px] text-[#414141] rotate-90 text-[18px] flex items-center justify-center">
-                  ⟳
-                </span>
-              </div>
-            ))}
-          </div>
+        <p
+          style={{
+            width: "300px",
+            height: "17px",
+            fontFamily: "Pretendard",
+            fontWeight: 600,
+            fontSize: "14px",
+            lineHeight: "120%",
+            letterSpacing: "-0.02em",
+            color: "#6B6B6B",
+            marginTop: "6px",
+          }}
+        >
+          카드를 눌러서 확인해 보세요 !
+        </p>
+      </div>
+      {/* ===== 모바일 - 궁합 카드 ===== */}
+      <div className="md:hidden px-3 hide-scrollbar overflow-x-auto">
+        <div className="w-max flex gap-[16px] ml-4 mr-4 mb-13 mt-5">
+          {goodCombinations.map((combo, i) => (
+            <div
+              key={i}
+              className="w-[130px] h-[114px] bg-white rounded-[14px] shadow-[2px_2px_12.2px_0px_#00000040] px-[6px] py-[10px] text-center text-[16px] font-medium flex items-center justify-center relative"
+            >
+              {combo}
+              <img
+                src={flipIcon}
+                alt="회전 아이콘"
+                className="absolute top-[10px] right-[10px] w-[20px] h-[20px] opacity-100"
+              />
+            </div>
+          ))}
         </div>
-        {/* PC용 제목 */}
-        <h2 className="hidden md:block w-[1500px] px-[35.64px] h-[38px] text-[32px] font-bold font-Pretendard leading-[120%] tracking-[-0.02em] text-black mb-6">
+      </div>
+      {/* PC용 제목 및 카드 wrapper */}
+      <div className="hidden md:block px-[230px]">
+        <h2 className="hidden md:block w-[1500px] h-[38px] text-[32px] font-bold font-Pretendard leading-[120%] tracking-[-0.02em] text-black mb-10 mt-20">
           궁합이 좋은 조합 TOP 5
+          <span className="ml-8 text-[22px] font-semibold font-Pretendard leading-[120%] tracking-[-0.02em] text-[#6B6B6B]">
+            카드를 눌러서 확인해 보세요 !
+          </span>
         </h2>
+
         {/* PC 카드 */}
-        <div className="hidden md:flex justify-center">
-          <div className="flex gap-[50px]">
-            {[
-              "철분 + 칼슘",
-              "아연 + 철분",
-              "아연 + 구리",
-              "비타민C + 철분",
-              "칼슘 + 마그네슘",
-            ].map((combo, i) => (
+        <div className="flex justify-start">
+          <div className="flex gap-[50px] mb-20">
+            {riskyCombinations.map((combo, i) => (
               <div
                 key={i}
                 className="w-[224px] h-[170px] rounded-[14px] px-[6px] py-[10px] 
-          bg-white text-[25px] font-normal flex items-center justify-center 
-          text-center shadow-[2px_2px_12.2px_0px_#00000040] relative"
+bg-white flex items-center justify-center 
+shadow-[2px_2px_12.2px_0px_#00000040] relative"
               >
-                {combo}
-                <span className="absolute top-[10px] right-[10px] w-[18px] h-[18px] text-[#414141] rotate-90 text-[18px] flex items-center justify-center">
-                  ⟳
+                <span className="w-[200px] h-[36px] font-pretendard font-medium text-[25px] leading-[100%] tracking-[0] text-[#414141] text-center">
+                  {combo}
+                  <img
+                    src={flipIcon}
+                    alt="회전 아이콘"
+                    className="absolute top-[10px] right-[10px] w-[25px] h-[25px] opacity-100"
+                  />
                 </span>
               </div>
             ))}

--- a/src/pages/combination/CombinationResultPage.tsx
+++ b/src/pages/combination/CombinationResultPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { MdArrowForwardIos, MdArrowBackIos } from "react-icons/md";
 import backgroundLine from "../../assets/background line.png";
+import boxIcon from "../../assets/box.png";
 import vitaminArrow from "../../assets/비타민 C_arrow.png";
 import selectionLine from "../../assets/selection line 1.png";
 
@@ -64,16 +65,16 @@ export default function CombinationResultPage() {
   };
 
   return (
-    <div className="w-full min-h-screen bg-[#FFFFFF] md:bg-[#FAFAFA] px-0 md:px-4 py-0 font-pretendard">
+    <div className="min-h-screen w-full bg-[#FFFFFF] md:bg-[#FAFAFA] px-0 md:px-4 py-0 font-pretendard flex flex-col">
+      {" "}
       {/* 조합분석 - 모바일 버전 */}
-      <h1 className="block md:hidden font-Pretendard font-bold text-[32px] leading-[100%] tracking-[-0.02em] mb-5 px-10 pt-10">
-        조합분석
+      <h1 className="block md:hidden font-Pretendard font-bold text-[32px] leading-[100%] tracking-[-0.02em] mb-2 px-10 pt-10">
+        조합 분석
       </h1>
-
       {/* 조합분석 - PC 버전 제목 + 버튼 수평 정렬 */}
       <div className="hidden md:flex justify-between items-start px-[230px] pt-[50px] mb-8">
         <h1 className="font-pretendard font-bold text-[52px] leading-[120%] tracking-[-0.02em]">
-          조합분석
+          조합 분석
         </h1>
         <div className="flex gap-4">
           <button
@@ -90,7 +91,6 @@ export default function CombinationResultPage() {
           </button>
         </div>
       </div>
-
       {/* PC 슬라이더 */}
       <div className="hidden md:block px-4">
         <div className="relative w-full max-w-[1430px] h-[300px] bg-white border border-[#B2B2B2] rounded-[45.51px] mx-auto px-[60px] py-[30px] overflow-hidden">
@@ -104,16 +104,26 @@ export default function CombinationResultPage() {
                   key={idx}
                   className="w-[270px] h-[250px] bg-white rounded-[22.76px] flex flex-col items-center pt-[80px] relative flex-shrink-0"
                 >
-                  <input
-                    type="checkbox"
-                    className="absolute top-[18px] left-[18px] w-[42px] h-[42px] border-2 border-[#9C9A9A] rounded-[7px] accent-black"
+                  <img
+                    src={boxIcon}
+                    alt="checkbox"
+                    className="absolute top-[10px] left-[18px] w-[50px] h-[50px]"
                   />
                   <img
                     src={item.imageUrl}
-                    alt={item.name}
-                    className="w-[100px] h-[100px] object-contain mb-2"
+                    className="w-[120px] h-[120px] object-contain mb-3 mt-[-25px]"
                   />
-                  <p className="text-sm font-medium text-center">{item.name}</p>
+                  <p
+                    className="text-center font-pretendard font-medium mt-1"
+                    style={{
+                      fontSize: "23px",
+                      lineHeight: "100%",
+                      letterSpacing: "-0.02em",
+                      color: "#000000",
+                    }}
+                  >
+                    {item.name}
+                  </p>
                 </div>
               )
             )}
@@ -137,9 +147,8 @@ export default function CombinationResultPage() {
           )}
         </div>
       </div>
-
       {/* 모바일 슬라이더 */}
-      <div className="md:hidden w-[390px] h-[156px] bg-white border border-[#B2B2B2] rounded-[20px] mx-auto overflow-x-auto scrollbar-hide px-4 py-3 mt-10">
+      <div className="md:hidden w-[370px] h-[156px] bg-white border border-[#B2B2B2] rounded-[20px] mx-auto overflow-x-auto scrollbar-hide px-4 py-3 mt-3">
         <div className="flex gap-3 w-max">
           {selectedItems.map((item: ProductItem, idx: number) => (
             <div
@@ -160,17 +169,15 @@ export default function CombinationResultPage() {
           ))}
         </div>
       </div>
-
       {/* 모바일 섭취알림 버튼 */}
       <div className="md:hidden mt-4 flex justify-center">
         <button
           onClick={() => navigate("/알림-편집-1")}
-          className="w-[370px] h-[54px] bg-[#FFEB9D] rounded-[14px] flex justify-center items-center"
+          className="w-[370px] h-[54px] bg-[#FFEB9D] rounded-[14px] flex justify-center items-center mt-2"
         >
           <span className="text-[20px] font-medium">섭취알림 등록하기 →</span>
         </button>
       </div>
-
       {/* PC 섭취량 탭 - 전체 / 초과 */}
       <div className="hidden md:block relative mt-[50px] mb-[40px]">
         {/* 탭 버튼 영역 */}
@@ -195,12 +202,7 @@ export default function CombinationResultPage() {
                   lineHeight: "120%",
                   letterSpacing: "-0.02em",
                   textAlign: "center",
-                  color:
-                    activeTab === tab
-                      ? tab === "초과"
-                        ? "#E70000"
-                        : "#000000"
-                      : "#BDBDBD",
+                  color: tab === "초과" ? "#E70000" : "#000000",
                 }}
               >
                 {tab}
@@ -222,9 +224,8 @@ export default function CombinationResultPage() {
           }}
         />
       </div>
-
       {/* 모바일 버전 탭 */}
-      <div className="relative flex flex-col items-center md:hidden mt-6">
+      <div className="relative flex flex-col items-center md:hidden mt-10">
         {/* 탭 버튼 */}
         <div className="flex justify-center gap-25 w-full z-10">
           {["전체", "초과"].map((tab) => (
@@ -247,12 +248,7 @@ export default function CombinationResultPage() {
                   lineHeight: "100%",
                   letterSpacing: "-0.02em",
                   textAlign: "center",
-                  color:
-                    activeTab === tab
-                      ? tab === "초과"
-                        ? "#E70000"
-                        : "#000000"
-                      : "#BDBDBD",
+                  color: tab === "초과" ? "#E70000" : "#000000",
                 }}
               >
                 {tab}
@@ -274,7 +270,6 @@ export default function CombinationResultPage() {
           }}
         />
       </div>
-
       {activeTab === "초과" && (
         <div className="bg-gray-100 rounded-xl py-3 px-4 text-center mb-6">
           <p className="text-sm font-semibold text-gray-700">
@@ -282,7 +277,6 @@ export default function CombinationResultPage() {
           </p>
         </div>
       )}
-
       {/* 모바일 섭취량 그래프 */}
       <div className="md:hidden space-y-4 px-4">
         {filteredIngredients.map(({ name, value, upper }) => {
@@ -348,7 +342,6 @@ export default function CombinationResultPage() {
           );
         })}
       </div>
-
       {/* PC 섭취량 그래프 */}
       <div className="hidden md:flex flex-col items-center space-y-6 px-[60px] mt-20">
         {filteredIngredients.map(({ name, value, upper }) => {
@@ -391,9 +384,8 @@ export default function CombinationResultPage() {
           );
         })}
       </div>
-
       {/* 주의가 필요한 조합 안내 - 모바일 */}
-      <div className="md:hidden px-7 mt-10 mb-4">
+      <div className="md:hidden px-7 mt-10">
         <h2
           style={{
             width: "390px",
@@ -424,14 +416,13 @@ export default function CombinationResultPage() {
           카드를 눌러서 확인해 보세요 !
         </p>
       </div>
-
       {/* 조합 카드들 - 모바일 */}
       <div className="md:hidden px-4 hide-scrollbar overflow-x-auto">
         <div className="w-max flex gap-[10px] ml-4 mr-4">
           {riskyCombinations.map((combo, i) => (
             <div
               key={i}
-              className="w-[130px] h-[114px] bg-white rounded-[14px] shadow-[2px_2px_12.2px_0px_#00000040] px-[6px] py-[10px] text-center text-[16px] font-medium flex items-center justify-center relative"
+              className="w-[130px] h-[114px] bg-white rounded-[14px] shadow-[2px_2px_12.2px_0px_#00000040] px-[6px] py-[10px] text-center text-[16px] font-medium flex items-center justify-center relative mt-5 mb-5"
             >
               {combo}
               <span className="absolute top-[10px] right-[10px] text-xs text-gray-400">
@@ -441,9 +432,8 @@ export default function CombinationResultPage() {
           ))}
         </div>
       </div>
-
       {/* 주의가 필요한 조합 안내 - PC */}
-      <div className="hidden md:block px-[60px] mt-[80px] mb-[40px]">
+      <div className="hidden md:block px-[60px] mt-[80px]">
         <h2
           style={{
             marginLeft: "200px",
@@ -480,16 +470,15 @@ export default function CombinationResultPage() {
           카드를 눌러서 확인해 보세요 !
         </p>
       </div>
-
       {/* 조합 카드들 - PC */}
-      <div className="hidden md:flex overflow-x-auto px-[60px] mb-[60px] justify-center">
-        <div className="flex gap-15 w-max ">
+      <div className="hidden md:flex overflow-x-auto px-[60px] justify-center">
+        <div className="flex gap-15 w-max mt-10 mb-5">
           {riskyCombinations.map((combo, i) => (
             <div
               key={i}
-              className="w-[224px] h-[170px] bg-white rounded-[14px] px-[6px] py-[10px] shadow-[2px_2px_12.2px_0px_rgba(0,0,0,0.25)] flex items-center justify-start relative"
+              className="w-[222px] h-[150px] bg-white rounded-[14px] px-[6px] py-[10px] shadow-[2px_2px_12.2px_0px_rgba(0,0,0,0.25)] flex items-center justify-start relative"
             >
-              <span className="w-[200px] h-[36px] font-pretendard font-medium text-[25px] leading-[100%] tracking-[0] text-[#414141] ml-[30px]">
+              <span className="w-[200px] h-[36px] font-pretendard font-medium text-[25px] leading-[100%] tracking-[0] text-[#414141] text-center mx-auto">
                 {combo}
               </span>
 
@@ -501,7 +490,7 @@ export default function CombinationResultPage() {
         </div>
       </div>
       {/* ===== 모바일 - 궁합이 좋은 조합 안내 ===== */}
-      <div className="md:hidden px-7 mt-10 mb-4">
+      <div className="md:hidden px-7 mt-10">
         <h2
           style={{
             width: "390px",
@@ -532,14 +521,13 @@ export default function CombinationResultPage() {
           카드를 눌러서 확인해 보세요 !
         </p>
       </div>
-
       {/* ===== 모바일 - 궁합 카드 ===== */}
-      <div className="md:hidden px-4 hide-scrollbar overflow-x-auto">
+      <div className="md:hidden px-4 hide-scrollbar overflow-x-auto mb-10">
         <div className="flex gap-3 w-max pl-4 pr-4">
           {goodCombinations.map((combo, i) => (
             <div
               key={i}
-              className="w-[130px] h-[114px] bg-white rounded-[14px] shadow-[2px_2px_12.2px_0px_#00000040] px-[6px] py-[10px] text-center text-[16px] font-medium flex items-center justify-center relative"
+              className="w-[130px] h-[114px] bg-white rounded-[14px] shadow-[2px_2px_12.2px_0px_#00000040] px-[6px] py-[10px] text-center text-[16px] font-medium flex items-center justify-center relative mt-5 mb-10"
             >
               {combo}
               <span className="absolute top-[10px] right-[10px] text-xs text-gray-400">
@@ -549,9 +537,8 @@ export default function CombinationResultPage() {
           ))}
         </div>
       </div>
-
       {/* ===== PC - 궁합이 좋은 조합 안내 ===== */}
-      <div className="hidden md:block px-[60px] mt-[80px] mb-[40px]">
+      <div className="hidden md:block px-[60px] mt-[80px]">
         <h2
           style={{
             marginLeft: "200px",
@@ -584,16 +571,15 @@ export default function CombinationResultPage() {
           카드를 눌러서 확인해 보세요 !
         </p>
       </div>
-
       {/* ===== PC - 궁합 카드 ===== */}
-      <div className="hidden md:block overflow-x-auto px-[60px] mb-[60px] ml-[200px]">
-        <div className="flex gap-15 w-max">
+      <div className="hidden md:flex overflow-x-auto px-[60px] justify-center">
+        <div className="flex gap-15 w-max mt-10 mb-30">
           {goodCombinations.map((combo, i) => (
             <div
               key={i}
-              className="w-[224px] h-[170px] bg-white rounded-[14px] px-[6px] py-[10px] shadow-[2px_2px_12.2px_0px_rgba(0,0,0,0.25)] flex items-center justify-center relative"
+              className="w-[222px] h-[150px] bg-white rounded-[14px] px-[6px] py-[10px] shadow-[2px_2px_12.2px_0px_rgba(0,0,0,0.25)] flex items-center justify-start relative"
             >
-              <span className="w-[200px] h-[36px] font-pretendard font-medium text-[25px] leading-[100%] tracking-[0] text-[#414141] text-center">
+              <span className="w-[200px] h-[36px] font-pretendard font-medium text-[25px] leading-[100%] tracking-[0] text-[#414141] text-center mx-auto">
                 {combo}
               </span>
 
@@ -602,7 +588,6 @@ export default function CombinationResultPage() {
               </span>
             </div>
           ))}
-          <div className="h-[120px] md:h-[140px]" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📝 작업 개요
- Combination 페이지 및 결과 페이지 일부 UI 수정

## ✅ 작업 내용
- 모바일에서 카드 좌상단에 box.png 아이콘 삽입 및 선택 시 checkbox.png로 변경
- 시작 버튼을 이미지(src/assets/시작.png)로 교체
- 선택된 카드 상단 삭제 버튼 ×를 이미지(delete.png)로 변경
- 선택된 제품 리스트 카드 안 약품명 텍스트 스타일 수정 (Pretendard, 28px, -2% letter-spacing 등 적용)
- PC 슬라이더 내 체크박스를 check box.png 이미지로 교체
- 결과 페이지 성분 섭취량 탭에서 "초과" 텍스트를 항상 #E70000으로 표시
- 기타 margin/padding 조정 및 이미지 위치 미세 조정