### PR TITLE
feat: AddCombinationPage 무한 렌더링 문제 수정

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 1.2.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tailwindcss/vite':
         specifier: ^4.1.11
-        version: 4.1.11(vite@7.0.0(@types/node@24.0.13)(jiti@2.4.2)(lightningcss@1.30.1))
+        version: 4.1.11(vite@7.0.5(@types/node@24.0.14)(jiti@2.4.2)(lightningcss@1.30.1))
       axios:
         specifier: ^1.11.0
         version: 1.11.0
@@ -65,7 +65,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^9.29.0
-        version: 9.30.1
+        version: 9.31.0
       '@types/axios':
         specifier: ^0.14.4
         version: 0.14.4
@@ -967,8 +967,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.179:
-    resolution: {integrity: sha512-UWKi/EbBopgfFsc5k61wFpV7WrnnSlSzW/e2XcBmS6qKYTivZlLtoll5/rdqRTxGglGHkmkW0j0pFNJG10EUIQ==}
+  electron-to-chromium@1.5.186:
+    resolution: {integrity: sha512-lur7L4BFklgepaJxj4DqPk7vKbTEl0pajNlg2QjE5shefmlmBLm2HvQ7PMf1R/GvlevT/581cop33/quQcfX3A==}
 
   enhanced-resolve@5.18.2:
     resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
@@ -990,9 +990,8 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.25.5:
-    resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
-
+  esbuild@0.25.6:
+    resolution: {integrity: sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2285,12 +2284,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@types/axios@0.14.4':
-    dependencies:
-      axios: 1.11.0
-    transitivePeerDependencies:
-      - debug
-
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.0
@@ -2552,7 +2545,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.179: {}
+  electron-to-chromium@1.5.186: {}
 
   enhanced-resolve@5.18.2:
     dependencies:
@@ -2574,7 +2567,7 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild@0.25.5:
+  esbuild@0.25.6:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.6
       '@esbuild/android-arm': 0.25.6

--- a/src/components/combination/CombinationProductCard.tsx
+++ b/src/components/combination/CombinationProductCard.tsx
@@ -19,7 +19,7 @@ export default function CombinationProductCard({
   const [checkedMobile, setCheckedMobile] = useState(false);
 
   const handleMobileToggle = (e: React.MouseEvent) => {
-    e.stopPropagation(); // 카드 클릭 막기
+    e.stopPropagation();
     setCheckedMobile((prev) => !prev);
     onToggle();
   };
@@ -49,13 +49,13 @@ export default function CombinationProductCard({
       <img
         src={item.imageUrl}
         className="mx-auto object-contain
-        w-[80px] h-[80px] md:w-[150px] md:h-[150px]"
+        w-[80px] h-[80px] mt-3 md:w-[150px] md:h-[150px]"
       />
 
       <div
         className="text-center font-pretendard font-medium
         text-[14px] leading-[120%] tracking-[-0.02em]
-        md:text-[22px] md:leading-[100%]"
+        mt-3 md:text-[20px] md:leading-[100%]"
       >
         {item.name}
       </div>
@@ -68,8 +68,8 @@ export default function CombinationProductCard({
         }}
         className="hidden md:block absolute text-[40px] text-[#1C1B1F]"
         style={{
-          top: "26.57px",
-          left: "237.45px",
+          top: "10px",
+          left: "245px",
           width: "27.2px",
           height: "27.19px",
         }}

--- a/src/pages/combination/AddCombinationPage.tsx
+++ b/src/pages/combination/AddCombinationPage.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams, useLocation } from "react-router-dom";
 import CombinationProductCard from "../../components/combination/CombinationProductCard";
 import ExpandableProductGroup from "../../components/combination/ExpandableProductGroup";
 import SadCat from "../../assets/sad-cat.png";
@@ -29,22 +29,38 @@ const mockProducts = [
 const AddCombinationPage = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const location = useLocation();
+
+  const query = searchParams.get("query") || "";
+  const selectedProductNames = query ? query.split(",") : [];
+  const preSelectedItems = location.state?.selectedItems || [];
+
   const [searchTerm, setSearchTerm] = useState("");
-  const [query, setQuery] = useState(searchParams.get("query") || "");
   const [selectedItems, setSelectedItems] = useState<any[]>([]);
   const [searchHistory, setSearchHistory] = useState<string[]>([]);
+
   const placeholder = "제품을 입력해주세요.";
 
+  // 첫 렌더링에만 실행되도록 useEffect 분리
   useEffect(() => {
-    const newQuery = searchParams.get("query") || "";
-    setQuery(newQuery);
-    setSearchTerm(newQuery);
-
     const stored = localStorage.getItem("searchHistory");
     if (stored) {
-      setSearchHistory(JSON.parse(stored));
+      const parsed = JSON.parse(stored);
+      setSearchHistory(parsed);
+
+      // 처음 마운트일 때만 설정
+      if (!searchTerm) {
+        setSearchTerm(parsed[0] || "");
+      }
     }
-  }, [searchParams]);
+  }, []); // 🔥 의존성 배열 비움
+
+  // selectedItems 업데이트는 location.state 있을 때만
+  useEffect(() => {
+    if (preSelectedItems.length > 0) {
+      setSelectedItems(preSelectedItems);
+    }
+  }, [preSelectedItems]);
 
   const handleSearch = () => {
     const trimmed = searchTerm.trim();
@@ -57,8 +73,11 @@ const AddCombinationPage = () => {
 
     localStorage.setItem("searchHistory", JSON.stringify(updated));
     setSearchHistory(updated);
-    setQuery(trimmed);
-    navigate(`/add-combination?query=${encodeURIComponent(trimmed)}`);
+
+    navigate(`/add-combination?query=${encodeURIComponent(trimmed)}`, {
+      replace: false,
+      state: { selectedItems },
+    });
   };
 
   const handleToggle = (item: any) => {
@@ -162,7 +181,6 @@ const AddCombinationPage = () => {
                 <button
                   onClick={() => {
                     setSearchTerm(item);
-                    setQuery(item);
                     navigate(
                       `/add-combination?query=${encodeURIComponent(item)}`
                     );
@@ -193,7 +211,11 @@ const AddCombinationPage = () => {
                 onClick={() => {
                   setSearchTerm(item);
                   navigate(
-                    `/add-combination?query=${encodeURIComponent(item)}`
+                    `/add-combination?query=${encodeURIComponent(item)}`,
+                    {
+                      replace: false,
+                      state: { selectedItems },
+                    }
                   );
                 }}
                 className="text-[20px] font-medium leading-[120%] tracking-[-0.02em] text-[#000000] hover:underline"
@@ -392,14 +414,14 @@ const AddCombinationPage = () => {
                     >
                       <img
                         src={item.imageUrl}
-                        className="w-[80px] h-[85px] object-contain mb-3"
+                        className="w-[80px] h-[80px] mt-2 object-contain mb-3"
                       />
-                      <p className="text-[12px] font-medium leading-[100%] tracking-[-0.02em] text-center font-pretendard text-black px-1">
+                      <p className="text-[13px] -mt-1 font-medium leading-[100%] tracking-[-0.02em] text-center font-pretendard text-black px-3">
                         {item.name}
                       </p>
                       <button
                         onClick={() => handleRemove(item.name)}
-                        className="absolute bottom-25 right-1"
+                        className="absolute bottom-23 right-1"
                       >
                         <img
                           src="/src/assets/delete.png"

--- a/src/pages/combination/CombinationResultPage.tsx
+++ b/src/pages/combination/CombinationResultPage.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { MdArrowForwardIos, MdArrowBackIos } from "react-icons/md";
 import backgroundLine from "../../assets/background line.png";
 import boxIcon from "../../assets/box.png";
+import checkedBoxIcon from "../../assets/check box.png";
 import vitaminArrow from "../../assets/비타민 C_arrow.png";
 import selectionLine from "../../assets/selection line 1.png";
 
@@ -14,6 +15,8 @@ type ProductItem = {
 export default function CombinationResultPage() {
   const location = useLocation();
   const selectedItems = location.state?.selectedItems || [];
+
+  const [checkedIndices, setCheckedIndices] = useState<number[]>([]);
   const navigate = useNavigate();
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -64,6 +67,24 @@ export default function CombinationResultPage() {
     }
   };
 
+  const handleToggleCheckbox = (idx: number) => {
+    setCheckedIndices((prev) =>
+      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx]
+    );
+  };
+
+  const handleRecombination = () => {
+    const selectedFiltered = selectedItems.filter((_: any, idx: number) =>
+      checkedIndices.includes(idx)
+    );
+
+    navigate("/add-combination", {
+      state: {
+        selectedItems,
+      },
+    });
+  };
+
   return (
     <div className="min-h-screen w-full bg-[#FFFFFF] md:bg-[#FAFAFA] px-0 md:px-4 py-0 font-pretendard flex flex-col">
       {" "}
@@ -78,14 +99,16 @@ export default function CombinationResultPage() {
         </h1>
         <div className="flex gap-4">
           <button
-            onClick={() => navigate("/조합-2-2")}
+            onClick={handleRecombination}
             className="w-[150px] h-[70px] bg-[#EEEEEE] rounded-full text-lg font-semibold flex items-center justify-center"
           >
             재조합
           </button>
           <button
-            onClick={() => navigate("/알림-2")}
-            className="w-[280px] h-[70px] bg-[#FFEB9D] rounded-[62.5px] text-lg font-semibold text-center"
+            onClick={() => navigate("/alarm/settings")}
+            className={`w-[280px] h-[70px] ${
+              checkedIndices.length > 0 ? "bg-[#FFEB9D]" : "bg-[#EEEEEE]"
+            } rounded-[62.5px] flex items-center justify-center`}
           >
             섭취알림 등록하기
           </button>
@@ -98,35 +121,35 @@ export default function CombinationResultPage() {
             ref={scrollRef}
             className="flex gap-[22.76px] overflow-x-auto scrollbar-hide scroll-smooth pr-[80px]"
           >
-            {selectedItems.map(
-              (item: { name: string; imageUrl: string }, idx: number) => (
-                <div
-                  key={idx}
-                  className="w-[270px] h-[250px] bg-white rounded-[22.76px] flex flex-col items-center pt-[80px] relative flex-shrink-0"
+            {selectedItems.map((item: ProductItem, idx: number) => (
+              <div
+                key={idx}
+                className="w-[270px] h-[250px] bg-white rounded-[22.76px] flex flex-col items-center pt-[80px] relative flex-shrink-0"
+              >
+                <img
+                  src={checkedIndices.includes(idx) ? checkedBoxIcon : boxIcon}
+                  alt="checkbox"
+                  onClick={() => handleToggleCheckbox(idx)}
+                  className="absolute top-[10px] left-[18px] w-[50px] h-[50px] cursor-pointer"
+                />
+
+                <img
+                  src={item.imageUrl}
+                  className="w-[120px] h-[120px] object-contain mb-3 mt-[-25px]"
+                />
+                <p
+                  className="text-center font-pretendard font-medium mt-1"
+                  style={{
+                    fontSize: "23px",
+                    lineHeight: "100%",
+                    letterSpacing: "-0.02em",
+                    color: "#000000",
+                  }}
                 >
-                  <img
-                    src={boxIcon}
-                    alt="checkbox"
-                    className="absolute top-[10px] left-[18px] w-[50px] h-[50px]"
-                  />
-                  <img
-                    src={item.imageUrl}
-                    className="w-[120px] h-[120px] object-contain mb-3 mt-[-25px]"
-                  />
-                  <p
-                    className="text-center font-pretendard font-medium mt-1"
-                    style={{
-                      fontSize: "23px",
-                      lineHeight: "100%",
-                      letterSpacing: "-0.02em",
-                      color: "#000000",
-                    }}
-                  >
-                    {item.name}
-                  </p>
-                </div>
-              )
-            )}
+                  {item.name}
+                </p>
+              </div>
+            ))}
           </div>
 
           {selectedItems.length > 4 && (


### PR DESCRIPTION
## 📝 작업 개요

- `AddCombinationPage`에서 무한 렌더링 이슈 해결
- preSelectedItems 또는 query 기반 selectedItems 설정 로직 정비
- 검색 기록 로직 개선 및 localStorage 반영 방식 통일

---

## ✅ 작업 내용

- useEffect 의존성 배열 최적화 (`selectedItems` 불필요한 업데이트 방지)
- 검색 기록 클릭 시 selectedItems 상태를 함께 전달하도록 개선
- `query` 기반 필터링 로직 정리 및 검색어 유지 처리
- 제품 선택/해제 시 상태 정확히 반영되도록 로직 개선

---