### PR TITLE
feat: 조합 분석 페이지 (PC/모바일) UI 개선 및 선택된 제품 시각화 구현

### DIFF
--- a/src/components/combination/CombinationProductCard.tsx
+++ b/src/components/combination/CombinationProductCard.tsx
@@ -16,66 +16,61 @@ export default function CombinationProductCard({
   isSelected,
   onToggle,
 }: Props) {
-  const [checkedMobile, setCheckedMobile] = useState(false);
+  const [checkedMobile] = useState(false);
 
   const handleMobileToggle = (e: React.MouseEvent) => {
     e.stopPropagation();
-    setCheckedMobile((prev) => !prev);
     onToggle();
   };
 
   return (
-    <div
-      className={`relative cursor-default box-border
-        ${checkedMobile ? "bg-[#EFEFEF]" : isSelected ? "bg-[#EEEEEE]" : "bg-white"}
-
-        // 모바일
-        w-[156px] h-[156px] pt-[34px] pr-[17px] pb-[14px] pl-[17px] rounded-[13px]
-        shadow-[2px_3px_12.4px_0px_rgba(0,0,0,0.16)]
-
-        // PC
-        md:w-[299px] md:h-[246px] md:p-[24px] md:rounded-[25px]
-        md:shadow-[2px_3px_12.4px_0px_rgba(0,0,0,0.16)] 
-        md:hover:shadow-lg
-      `}
-    >
-      <img
-        src={checkedMobile ? checkboxIcon : boxIcon}
-        alt="check"
-        onClick={handleMobileToggle}
-        className="absolute top-[12px] left-[12px] w-[30px] h-[30px] md:hidden cursor-pointer"
-      />
-
-      <img
-        src={item.imageUrl}
-        className="mx-auto object-contain
-        w-[80px] h-[80px] mt-3 md:w-[150px] md:h-[150px]"
-      />
-
+    <>
+      {/* 모바일 카드 */}
       <div
-        className="text-center font-pretendard font-medium
-        text-[14px] leading-[120%] tracking-[-0.02em]
-        mt-3 md:text-[20px] md:leading-[100%]"
+        className={`relative md:hidden box-border cursor-default
+        ${isSelected ? "bg-[#EFEFEF]" : "bg-white"}
+        w-[156px] h-[156px] p-[17px] pt-[34px] rounded-[13px]
+        shadow-[2px_3px_12.4px_0px_rgba(0,0,0,0.16)]`}
       >
-        {item.name}
+        <img
+          src={isSelected ? checkboxIcon : boxIcon}
+          alt="check"
+          onClick={handleMobileToggle}
+          className="absolute top-[12px] left-[12px] w-[30px] h-[30px] cursor-pointer"
+        />
+        <img
+          src={item.imageUrl}
+          className="mx-auto w-[80px] h-[80px] object-contain -mt-2"
+        />
+        <p className="text-center font-pretendard font-medium text-[14px] mt-2 tracking-[-0.02em] leading-[120%]">
+          {item.name}
+        </p>
       </div>
 
-      {/* 선택/해제 버튼 */}
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onToggle();
-        }}
-        className="hidden md:block absolute text-[40px] text-[#1C1B1F]"
-        style={{
-          top: "10px",
-          left: "245px",
-          width: "27.2px",
-          height: "27.19px",
-        }}
+      {/* PC 카드 */}
+      <div
+        className={`hidden md:block relative box-border cursor-default
+        ${isSelected ? "bg-[#EEEEEE]" : "bg-white"}
+        w-[299px] h-[246px] rounded-[25px] p-[30px]
+        shadow-[2px_3px_12.4px_0px_rgba(0,0,0,0.16)] hover:shadow-lg`}
       >
-        {isSelected ? "—" : "+"}
-      </button>
-    </div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggle();
+          }}
+          className="absolute top-[10px] left-[245px] text-[40px] text-[#1C1B1F]"
+        >
+          {isSelected ? "—" : "+"}
+        </button>
+        <img
+          src={item.imageUrl}
+          className="mx-auto w-[145px] h-[145px] object-contain mt-2"
+        />
+        <p className="text-center font-pretendard font-medium text-[20px] tracking-[-0.02em] leading-[100%] mt-4">
+          {item.name}
+        </p>
+      </div>
+    </>
   );
 }

--- a/src/pages/combination/AddCombinationPage.tsx
+++ b/src/pages/combination/AddCombinationPage.tsx
@@ -48,14 +48,12 @@ const AddCombinationPage = () => {
       const parsed = JSON.parse(stored);
       setSearchHistory(parsed);
 
-      // 처음 마운트일 때만 설정
       if (!searchTerm) {
         setSearchTerm(parsed[0] || "");
       }
     }
-  }, []); // 🔥 의존성 배열 비움
+  }, []);
 
-  // selectedItems 업데이트는 location.state 있을 때만
   useEffect(() => {
     if (preSelectedItems.length > 0) {
       setSelectedItems(preSelectedItems);

--- a/src/pages/combination/CombinationResultPage.tsx
+++ b/src/pages/combination/CombinationResultPage.tsx
@@ -2,10 +2,11 @@ import { useState, useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { MdArrowForwardIos, MdArrowBackIos } from "react-icons/md";
 import backgroundLine from "../../assets/background line.png";
-import boxIcon from "../../assets/box.png";
 import checkedBoxIcon from "../../assets/check box.png";
 import vitaminArrow from "../../assets/비타민 C_arrow.png";
 import selectionLine from "../../assets/selection line 1.png";
+import checkboxIcon from "../../assets/check box.png";
+import boxIcon from "../../assets/box.png";
 
 type ProductItem = {
   name: string;
@@ -80,7 +81,7 @@ export default function CombinationResultPage() {
 
     navigate("/add-combination", {
       state: {
-        selectedItems,
+        selectedItems: selectedFiltered,
       },
     });
   };
@@ -124,7 +125,8 @@ export default function CombinationResultPage() {
             {selectedItems.map((item: ProductItem, idx: number) => (
               <div
                 key={idx}
-                className="w-[270px] h-[250px] bg-white rounded-[22.76px] flex flex-col items-center pt-[80px] relative flex-shrink-0"
+                className={`w-[270px] h-[250px] rounded-[22.76px] flex flex-col items-center pt-[80px] relative flex-shrink-0
+                ${checkedIndices.includes(idx) ? "bg-[#EEEEEE]" : "bg-white"}`}
               >
                 <img
                   src={checkedIndices.includes(idx) ? checkedBoxIcon : boxIcon}
@@ -176,18 +178,29 @@ export default function CombinationResultPage() {
           {selectedItems.map((item: ProductItem, idx: number) => (
             <div
               key={idx}
-              className="w-[130px] h-[130px] bg-white rounded-[10px] flex flex-col items-center relative flex-shrink-0 pt-[26px] pb-[12px]"
+              className={`w-[130px] h-[130px] rounded-[10px] flex flex-col items-center relative flex-shrink-0 pt-[26px] pb-[12px]
+        ${checkedIndices.includes(idx) ? "bg-[#EFEFEF]" : "bg-white"}
+        ${checkedIndices.includes(idx) ? "shadow-[2px_3px_12.4px_0px_rgba(0,0,0,0.16)]" : ""}
+        `}
             >
-              <input
-                type="checkbox"
-                className="absolute top-[8px] left-[8px] w-[18px] h-[18px] border border-[#9C9A9A] rounded-[3.33px] accent-black"
+              {/* 이미지 체크박스 */}
+              <img
+                src={checkedIndices.includes(idx) ? checkboxIcon : boxIcon}
+                alt="checkbox"
+                onClick={() => handleToggleCheckbox(idx)}
+                className="absolute top-[2px] left-[2px] w-[30px] h-[30px] cursor-pointer"
               />
+
+              {/* 제품 이미지 */}
               <img
                 src={item.imageUrl}
-                alt={item.name}
-                className="w-[70px] h-[50px] object-contain mb-2"
+                className="w-[70px] h-[70px] object-contain -mt-2 mb-2"
               />
-              <p className="text-xs text-center px-1">{item.name}</p>
+
+              {/* 제품 이름 */}
+              <p className="font-pretendard font-medium text-[15px] leading-[100%] tracking-[-0.02em] text-center text-black">
+                {item.name}
+              </p>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## 📝 작업 개요
- 조합 분석 페이지 (PC/모바일) UI 개선 및 선택된 제품 시각화 구현

## ✅ 작업 내용
- 모바일 슬라이더에서 이미지 기반 카드 컴포넌트로 변경
  - 기존 `<input type="checkbox">` 방식 제거
  - `boxIcon`, `checkboxIcon` 이미지 기반으로 대체
- 선택 여부에 따라 카드 배경, 체크박스 이미지, 그림자 조건부 렌더링 적용
  - 미선택 시 border/그림자/배경 없음
  - 선택 시 `bg-[#EEEEEE]` 및 `shadow` 스타일 적용
- Figma 명세서 기준으로 이미지 크기 및 위치 수정
  - PC: 이미지 `w-[120px] h-[120px]` → `w-[70px] h-[70px]` 등 조정
  - 텍스트: Pretendard, font-size: 28px, line-height: 100%, tracking: -2%
- 모바일/PC 각각 카드 텍스트 스타일 통일
  - `font-medium`, `tracking-[-0.02em]`, `text-center`
- 상단 "재조합", "섭취알림 등록하기" 버튼 영역
  - PC 버전: `share.png`, `재조합.png` 아이콘 포함하도록 레이아웃 수정 예정
- 에러 해결
  - `checkboxIcon is not defined` 오류 → import 누락 확인 및 수정