### PR TITLE
feat: 이메일 회원가입 1·2단계 API 연동 및 임시 토큰 처리 추가

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,175 +1,104 @@
-// // import axios from "axios";
-
-// // const BASE_URL = import.meta.env.VITE_SERVER_API_URL;
-
-// // export const postSocialSignup = async (data: {
-// //   email: string;
-// //   nickname: string;
-// //   birth: string;
-// //   gender: string;
-// //   phoneNumber: string;
-// // }) => {
-// //   const response = await axios.post(
-// //     `${BASE_URL}/api/v1/auth/social-signup`,
-// //     data
-// //   );
-// //   return response.data;
-// // };
-
-// // FILE: src/apis/auth.ts
-// import axios from "axios";
-
-// const BASE_URL = import.meta.env.VITE_SERVER_API_URL;
-
-// // 백엔드 스펙에 맞춤
-// export type SocialSignupPayload = {
-//   email: string;
-//   fullName: string;
-//   provider: string;
-//   providerId: string;
-//   nickname: string;
-//   gender: "MALE" | "FEMALE" | "OTHER";
-//   birthDate: string; // ✅ birth → birthDate
-//   phoneNumber: string;
-// };
-
-// // 응답은 프로젝트마다 달라 방어적 타입
-// export type SocialSignupResponse = {
-//   isSuccess?: boolean;
-//   result?: {
-//     accessToken?: string;
-//     refreshToken?: string;
-//   };
-//   accessToken?: string;
-//   refreshToken?: string;
-// };
-
-// export const postSocialSignup = (data: SocialSignupPayload) => {
-//   // headers(Authorization)도 접근할 수 있게 응답 전체 반환
-//   return axios.post<SocialSignupResponse>(
-//     `${BASE_URL}/api/v1/auth/social-signup`,
-//     data,
-//     { withCredentials: true }
-//   );
-// };
-
-// import axios from "axios";
-// import type { AxiosRequestConfig } from "axios";
-
-// const BASE_URL = import.meta.env.VITE_SERVER_API_URL;
-
-// // 백엔드 스펙에 맞춤
-// export type SocialSignupPayload = {
-//   email: string;
-//   fullName: string;
-//   provider: string;
-//   providerId: string;
-//   nickname: string;
-//   gender: "MALE" | "FEMALE" | "OTHER";
-//   birthDate: string; // ✅ birth → birthDate
-//   phoneNumber: string;
-// };
-
-// // 응답은 프로젝트마다 달라 방어적 타입
-// export type SocialSignupResponse = {
-//   isSuccess?: boolean;
-//   result?: {
-//     accessToken?: string;
-//     refreshToken?: string;
-//   };
-//   accessToken?: string;
-//   refreshToken?: string;
-// };
-
-// /**
-//  * 소셜 회원가입을 요청하는 API 함수
-//  * @param data - 회원가입에 필요한 유저 정보
-//  * @param socialTempToken - 소셜 로그인 직후 발급된 임시 인증 토큰
-//  * @returns Axios Promise
-//  */
-// export const postSocialSignup = (
-//   data: SocialSignupPayload,
-//   socialTempToken?: string // 1. 임시 토큰을 두 번째 인자로 받도록 추가 (옵셔널)
-// ) => {
-//   // 2. Axios 요청 설정을 준비합니다.
-//   const config: AxiosRequestConfig = {
-//     // 기존의 withCredentials 설정은 그대로 유지합니다.
-//     withCredentials: true,
-//   };
-
-//   // 3. socialTempToken이 전달된 경우, config 객체에 Authorization 헤더를 추가합니다.
-//   if (socialTempToken) {
-//     config.headers = {
-//       Authorization: `Bearer ${socialTempToken}`,
-//     };
-//   }
-
-//   // headers(Authorization)도 접근할 수 있게 응답 전체 반환
-//   // 4. 수정된 config 객체를 사용하여 요청을 보냅니다.
-//   return axios.post<SocialSignupResponse>(
-//     `${BASE_URL}/api/v1/auth/social-signup`,
-//     data,
-//     config
-//   );
-// };
-
-// FILE: src/apis/auth.ts
-// import axios, { type AxiosRequestConfig } from "axios";
-
-// const BASE_URL = import.meta.env.VITE_SERVER_API_URL;
-
-// export type SocialSignupPayload = {
-//   email: string;
-//   fullName: string;
-//   provider: string;
-//   providerId: string;
-//   nickname: string;
-//   gender: "MALE" | "FEMALE" | "OTHER";
-//   birthDate: string;
-//   phoneNumber: string;
-// };
-
-// export type SocialSignupResponse = {
-//   isSuccess?: boolean;
-//   result?: {
-//     accessToken?: string;
-//     refreshToken?: string;
-//   };
-//   accessToken?: string;
-//   refreshToken?: string;
-// };
-
-// /**
-//  * 소셜 회원가입
-//  * - URL로 전달받은 임시토큰(signupToken/socialTempToken)을 Authorization 헤더에 넣어서 호출
-//  * - 쿠키 방식과도 호환(withCredentials:true 유지)
-//  */
-// export const postSocialSignup = (
-//   data: SocialSignupPayload,
-//   socialTempToken?: string
-// ) => {
-//   const config: AxiosRequestConfig = {
-//     withCredentials: true, // 쿠키 방식 병행 가능
-//     timeout: 15000,
-//     headers: {
-//       "Content-Type": "application/json",
-//       ...(socialTempToken
-//         ? { Authorization: `Bearer ${socialTempToken}` }
-//         : undefined),
-//     },
-//     // 필요시: validateStatus: (s) => s < 500,
-//   };
-
-//   return axios.post<SocialSignupResponse>(
-//     `${BASE_URL}/api/v1/auth/social-signup`,
-//     data,
-//     config
-//   );
-// };
-import axios, { type AxiosRequestConfig } from "axios";
-
+import axios from "axios";
 const BASE_URL = import.meta.env.VITE_SERVER_API_URL;
 
+/* =========================
+   이메일 1단계: pre-signup
+   ========================= */
+export type PreSignupPayload = {
+  email: string;
+  password: string;
+  nickname: string;
+  agreedTermIds: number[];
+};
+
+export type PreSignupResponseRaw = {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: string; // JWT 토큰
+};
+
+export type PreSignupResponse = {
+  preSignupToken: string;
+};
+
+export const postPreSignup = async (
+  data: PreSignupPayload
+): Promise<PreSignupResponse> => {
+  const res = await axios.post<PreSignupResponseRaw>(
+    `${BASE_URL}/api/v1/auth/pre-signup`,
+    data,
+    {
+      headers: { "Content-Type": "application/json" },
+      withCredentials: true,
+      timeout: 15000,
+    }
+  );
+
+  const token = res?.data?.result;
+  if (!token) {
+    // 응답 스펙 변경/오류 시 빠르게 알기 위함
+    throw new Error("pre-signup 응답에 result(토큰)가 없습니다.");
+  }
+  return { preSignupToken: token };
+};
+
+/* =========================
+   이메일 2단계: signup
+   ========================= */
+export type FinalSignupPayload = {
+  fullName: string;
+  gender: "MALE" | "FEMALE" | "OTHER";
+  birthDate: string; // yyyy-MM-dd
+  phoneNumber: string; // 010-1234-5678
+};
+export type FinalSignupResponse = {
+  accessToken?: string;
+  refreshToken?: string;
+  result?: { accessToken?: string; refreshToken?: string };
+};
+
+export const postFinalSignup = async (
+  data: FinalSignupPayload,
+  preSignupToken: string
+): Promise<FinalSignupResponse> => {
+  const res = await axios.post<FinalSignupResponse>(
+    `${BASE_URL}/api/v1/auth/signup`,
+    data,
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${preSignupToken}`,
+      },
+      withCredentials: true,
+      timeout: 15000,
+    }
+  );
+  return res.data;
+};
+
+/* =========================
+   (선택) 로그인 후 추가 약관 동의
+   ========================= */
+export type AgreeTermsPayload = { agreedTermIds: number[] };
+export const postAgreeTerms = async (
+  payload: AgreeTermsPayload,
+  accessToken: string
+) => {
+  const res = await axios.post(`${BASE_URL}/api/v1/terms/agreements`, payload, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    withCredentials: true,
+    timeout: 15000,
+  });
+  return res.data;
+};
+
+/* =========================
+   (유지) 소셜 전용 API
+   ========================= */
 export type SocialSignupPayload = {
   email: string;
   fullName: string;
@@ -180,30 +109,36 @@ export type SocialSignupPayload = {
   birthDate: string;
   phoneNumber: string;
 };
-
 export type SocialSignupResponse = {
   isSuccess?: boolean;
   result?: { accessToken?: string; refreshToken?: string };
   accessToken?: string;
   refreshToken?: string;
 };
-
 export const postSocialSignup = (
   data: SocialSignupPayload,
   signupToken?: string
 ) => {
-  const config: AxiosRequestConfig = {
-    withCredentials: true,
-    timeout: 15000,
-    headers: {
-      "Content-Type": "application/json",
-      ...(signupToken ? { Authorization: `Bearer ${signupToken}` } : undefined),
-    },
-  };
-
   return axios.post<SocialSignupResponse>(
     `${BASE_URL}/api/v1/auth/social-signup`,
     data,
-    config
+    {
+      withCredentials: true,
+      timeout: 15000,
+      headers: {
+        "Content-Type": "application/json",
+        ...(signupToken
+          ? { Authorization: `Bearer ${signupToken}` }
+          : undefined),
+      },
+    }
   );
 };
+
+/* =========================
+   (편의) 최종 응답에서 토큰 꺼내기
+   ========================= */
+export const unwrapFinalTokens = (r: FinalSignupResponse) => ({
+  accessToken: r.accessToken ?? r.result?.accessToken,
+  refreshToken: r.refreshToken ?? r.result?.refreshToken,
+});

--- a/src/components/ingredient/IngredientSupplements.tsx
+++ b/src/components/ingredient/IngredientSupplements.tsx
@@ -301,6 +301,7 @@ const IngredientSupplements = ({ data }: Props) => {
         {filteredProducts.map((product) => (
           <div key={product.id} className="flex justify-center">
             <ProductCard
+              id={product.id} // 현서 수정
               name={product.name}
               imageSrc={product.imageUrl} // string 보장
             />

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -14,4 +14,14 @@ instance.interceptors.request.use((config) => {
   return config;
 });
 
+instance.interceptors.request.use((config) => {
+  if (config.url?.includes("/api/v1/auth/signup")) {
+    console.debug(
+      "[request → /auth/signup] headers.Authorization:",
+      config.headers?.Authorization
+    );
+  }
+  return config;
+});
+
 export default instance;

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,5 +1,0 @@
-const SignInPage = () => {
-  return <div>SignInPage</div>;
-};
-
-export default SignInPage;

--- a/src/pages/alarm/DesktopAlarmSettingsPage.tsx
+++ b/src/pages/alarm/DesktopAlarmSettingsPage.tsx
@@ -262,7 +262,7 @@ const DesktopAlarmSettingsPage = () => {
           <div
             ref={menuRef}
             role="menu"
-            className="absolute right-0 top-[72px] w-[466px] h-[310px] rounded-2xl shadow-xl bg-white border border-gray-100 p-4 z-50"
+            className="absolute right-0 top-[72px] w-[466px] rounded-2xl shadow-xl bg-white border border-gray-100 p-4 z-50"
           >
             <div className="px-2 py-1 text-[22px] text-black font-medium">
               영양제 추가하기
@@ -279,7 +279,10 @@ const DesktopAlarmSettingsPage = () => {
               className="w-full flex items-center gap-3 px-3 py-3 rounded-xl hover:bg-gray-50 transition"
             >
               <span className="inline-flex items-center justify-center w-[70px] h-[70px] rounded-full bg-gray-100">
-                <FiSearch className="text-xl w-[48px] h-[48px]" />
+                <img
+                  src="/images/search.png"
+                  className="text-xl w-[48px] h-[48px]"
+                />
               </span>
               <div className="text-left">
                 <div className="text-[20px] font-semibold">제품 검색하기</div>
@@ -298,9 +301,12 @@ const DesktopAlarmSettingsPage = () => {
               className="w-full flex items-center gap-3 px-3 py-3 rounded-xl hover:bg-gray-50 transition"
             >
               <span className="inline-flex items-center justify-center w-[70px] h-[70px] rounded-full bg-gray-100">
-                <FiType className="text-xl w-[48px] h-[48px]" />
+                <img
+                  src="/images/text.png"
+                  className="text-xl w-[48px] h-[48px]"
+                />
               </span>
-              <div className="text-[16px] font-semibold">직접 입력하기</div>
+              <div className="text-[20px] font-semibold">직접 입력하기</div>
             </button>
           </div>
         )}

--- a/src/pages/auth/DesktopEmailSignupDetailPage.tsx
+++ b/src/pages/auth/DesktopEmailSignupDetailPage.tsx
@@ -1,16 +1,201 @@
+// import { useEffect, useMemo, useState } from "react";
+// import { useNavigate } from "react-router-dom";
+// import axios from "@/lib/axios";
+
+// const DesktopEmailSignupDetailPage = () => {
+//   const [gender, setGender] = useState<"FEMALE" | "MALE" | null>(null);
+//   const [birth, setBirth] = useState("");
+//   const [phone, setPhone] = useState("");
+//   const [error, setError] = useState("");
+//   const [isSubmitting, setIsSubmitting] = useState(false);
+//   const navigate = useNavigate();
+
+//   // 1단계 데이터 불러오기
+//   const base = useMemo(() => {
+//     try {
+//       const raw = sessionStorage.getItem("signupData");
+//       return raw ? JSON.parse(raw) : null;
+//     } catch {
+//       return null;
+//     }
+//   }, []);
+
+//   useEffect(() => {
+//     if (!base?.email || !base?.password || !base?.nickname) {
+//       navigate("/signup/email", { replace: true });
+//     }
+//   }, [base, navigate]);
+
+//   const genderCardStyle = (selected: boolean) =>
+//     `w-[160px] h-[180px] rounded-xl border border-gray-200 flex justify-center items-center cursor-pointer shadow-sm transition ${
+//       selected ? "bg-[#FFF8DC] border-none" : "bg-white"
+//     }`;
+
+//   // 생년월일 입력 자동 포맷 (YYYY.MM.DD)
+//   const handleBirthChange = (value: string) => {
+//     // 숫자만 추출
+//     const onlyNums = value.replace(/\D/g, "").slice(0, 8);
+//     let formatted = onlyNums;
+//     if (onlyNums.length > 4) {
+//       formatted = onlyNums.slice(0, 4) + "." + onlyNums.slice(4);
+//     }
+//     if (onlyNums.length > 6) {
+//       formatted =
+//         onlyNums.slice(0, 4) +
+//         "." +
+//         onlyNums.slice(4, 6) +
+//         "." +
+//         onlyNums.slice(6);
+//     }
+//     setBirth(formatted);
+//   };
+
+//   // 전화번호 입력 자동 포맷 (010-1234-5678)
+//   const handlePhoneChange = (value: string) => {
+//     const onlyNums = value.replace(/\D/g, "").slice(0, 11);
+//     let formatted = onlyNums;
+//     if (onlyNums.length > 3 && onlyNums.length <= 7) {
+//       formatted = onlyNums.slice(0, 3) + "-" + onlyNums.slice(3);
+//     } else if (onlyNums.length > 7) {
+//       formatted =
+//         onlyNums.slice(0, 3) +
+//         "-" +
+//         onlyNums.slice(3, 7) +
+//         "-" +
+//         onlyNums.slice(7);
+//     }
+//     setPhone(formatted);
+//   };
+
+//   const handleSubmit = async (e: React.FormEvent) => {
+//     e.preventDefault();
+//     setError("");
+
+//     if (!gender) {
+//       setError("성별을 선택해주세요.");
+//       return;
+//     }
+
+//     // 서버 전송용 포맷 변환
+//     const birthDate = birth.replace(/\./g, "-"); // YYYY-MM-DD
+//     const phoneNumber = phone; // 이미 010-1234-5678 형태
+
+//     const body = {
+//       email: base.email,
+//       password: base.password,
+//       fullName: base.nickname,
+//       nickname: base.nickname,
+//       gender,
+//       birthDate,
+//       phoneNumber,
+//       agreeToMarketing: !!base.agreeToMarketing,
+//     };
+
+//     try {
+//       setIsSubmitting(true);
+//       await axios.post("/api/v1/auth/signup", body);
+//       sessionStorage.removeItem("signupData");
+//       navigate("/login/email");
+//     } catch (err: any) {
+//       const msg =
+//         err?.response?.data?.message ||
+//         "회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.";
+//       setError(msg);
+//       console.error("Signup error:", err);
+//     } finally {
+//       setIsSubmitting(false);
+//     }
+//   };
+
+//   return (
+//     <div className="flex flex-col items-center min-h-screen bg-[#FAFAFA] py-10">
+//       <h1 className="text-[34px] font-medium mb-10">회원가입</h1>
+
+//       <form onSubmit={handleSubmit} className="w-full max-w-md space-y-8">
+//         {/* 성별 선택 */}
+//         <div className="flex justify-between gap-4">
+//           <div className="flex flex-col items-center gap-2">
+//             <div
+//               onClick={() => setGender("FEMALE")}
+//               className={genderCardStyle(gender === "FEMALE")}
+//             >
+//               <img src="/images/female.png" alt="여성" className="w-[151px]" />
+//             </div>
+//             <p className="text-[22px] font-semibold">여성</p>
+//           </div>
+
+//           <div className="flex flex-col items-center gap-2">
+//             <div
+//               onClick={() => setGender("MALE")}
+//               className={genderCardStyle(gender === "MALE")}
+//             >
+//               <img src="/images/male.png" alt="남성" className="w-[151px]" />
+//             </div>
+//             <span className="text-[22px] font-semibold">남성</span>
+//           </div>
+//         </div>
+
+//         {/* 생년월일 */}
+//         <div>
+//           <label className="block text-[18px] font-semibold mb-2">
+//             생년월일
+//           </label>
+//           <input
+//             type="text"
+//             placeholder="YYYY.MM.DD"
+//             value={birth}
+//             onChange={(e) => handleBirthChange(e.target.value)}
+//             className="w-full border-b border-gray-300 py-2 px-1 text-[18px] focus:outline-none"
+//             required
+//           />
+//         </div>
+
+//         {/* 휴대폰 번호 */}
+//         <div>
+//           <label className="block text-[18px] font-semibold mb-2">
+//             휴대폰 번호
+//           </label>
+//           <input
+//             type="text"
+//             placeholder="010-1234-1234"
+//             value={phone}
+//             onChange={(e) => handlePhoneChange(e.target.value)}
+//             className="w-full border-b border-gray-300 py-2 px-1 text-[18px] focus:outline-none"
+//             required
+//           />
+//         </div>
+
+//         {error && <p className="text-red-500 text-sm">{error}</p>}
+
+//         <button
+//           type="submit"
+//           disabled={isSubmitting}
+//           className="w-full h-[82px] bg-[#FFEB9D] text-black text-[20px] font-bold rounded-lg disabled:opacity-60"
+//         >
+//           {isSubmitting ? "처리 중..." : "회원가입 완료하기"}
+//         </button>
+//       </form>
+//     </div>
+//   );
+// };
+
+// export default DesktopEmailSignupDetailPage;
+
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "@/lib/axios";
 
-const SignupDetailsPage = () => {
-  const [gender, setGender] = useState<"FEMALE" | "MALE" | null>(null);
-  const [birth, setBirth] = useState("");
-  const [phone, setPhone] = useState("");
+const DesktopEmailSignupDetailPage = () => {
+  const [gender, setGender] = useState<"FEMALE" | "MALE" | "OTHER" | null>(
+    null
+  );
+  const [birth, setBirth] = useState(""); // UI: YYYY.MM.DD
+  const [phone, setPhone] = useState(""); // UI: 010-1234-5678
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const navigate = useNavigate();
 
-  // 1단계 데이터 불러오기
+  // 1단계 데이터 + 임시 토큰 불러오기
   const base = useMemo(() => {
     try {
       const raw = sessionStorage.getItem("signupData");
@@ -20,11 +205,16 @@ const SignupDetailsPage = () => {
     }
   }, []);
 
+  const preSignupToken = useMemo(() => {
+    return sessionStorage.getItem("preSignupToken"); // ✅ 1단계에서 저장해야 함
+  }, []);
+
   useEffect(() => {
-    if (!base?.email || !base?.password || !base?.nickname) {
+    // 필수 데이터/토큰 없으면 1단계로
+    if (!base?.email || !base?.password || !base?.nickname || !preSignupToken) {
       navigate("/signup/email", { replace: true });
     }
-  }, [base, navigate]);
+  }, [base, preSignupToken, navigate]);
 
   const genderCardStyle = (selected: boolean) =>
     `w-[160px] h-[180px] rounded-xl border border-gray-200 flex justify-center items-center cursor-pointer shadow-sm transition ${
@@ -33,20 +223,12 @@ const SignupDetailsPage = () => {
 
   // 생년월일 입력 자동 포맷 (YYYY.MM.DD)
   const handleBirthChange = (value: string) => {
-    // 숫자만 추출
     const onlyNums = value.replace(/\D/g, "").slice(0, 8);
     let formatted = onlyNums;
-    if (onlyNums.length > 4) {
-      formatted = onlyNums.slice(0, 4) + "." + onlyNums.slice(4);
-    }
-    if (onlyNums.length > 6) {
-      formatted =
-        onlyNums.slice(0, 4) +
-        "." +
-        onlyNums.slice(4, 6) +
-        "." +
-        onlyNums.slice(6);
-    }
+    if (onlyNums.length > 4)
+      formatted = `${onlyNums.slice(0, 4)}.${onlyNums.slice(4)}`;
+    if (onlyNums.length > 6)
+      formatted = `${onlyNums.slice(0, 4)}.${onlyNums.slice(4, 6)}.${onlyNums.slice(6)}`;
     setBirth(formatted);
   };
 
@@ -55,51 +237,64 @@ const SignupDetailsPage = () => {
     const onlyNums = value.replace(/\D/g, "").slice(0, 11);
     let formatted = onlyNums;
     if (onlyNums.length > 3 && onlyNums.length <= 7) {
-      formatted = onlyNums.slice(0, 3) + "-" + onlyNums.slice(3);
+      formatted = `${onlyNums.slice(0, 3)}-${onlyNums.slice(3)}`;
     } else if (onlyNums.length > 7) {
-      formatted =
-        onlyNums.slice(0, 3) +
-        "-" +
-        onlyNums.slice(3, 7) +
-        "-" +
-        onlyNums.slice(7);
+      formatted = `${onlyNums.slice(0, 3)}-${onlyNums.slice(3, 7)}-${onlyNums.slice(7)}`;
     }
     setPhone(formatted);
+  };
+
+  // 클라이언트 검증(간단)
+  const validate = () => {
+    if (!gender) return "성별을 선택해주세요.";
+    const birthDate = birth.replace(/\./g, "-"); // -> YYYY-MM-DD
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(birthDate))
+      return "생년월일 형식이 올바르지 않습니다.";
+    if (!/^010-\d{4}-\d{4}$/.test(phone))
+      return "휴대폰 번호 형식이 올바르지 않습니다.";
+    return "";
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
 
-    if (!gender) {
-      setError("성별을 선택해주세요.");
+    const v = validate();
+    if (v) {
+      setError(v);
       return;
     }
 
-    // 서버 전송용 포맷 변환
+    // 서버 전송용 포맷
     const birthDate = birth.replace(/\./g, "-"); // YYYY-MM-DD
-    const phoneNumber = phone; // 이미 010-1234-5678 형태
+    const phoneNumber = phone;
 
+    // ⚠️ 최종 가입 바디는 스펙에 맞춰 "이 4개만" 보냄
     const body = {
-      email: base.email,
-      password: base.password,
-      fullName: base.nickname,
-      nickname: base.nickname,
-      gender,
-      birthDate,
-      phoneNumber,
-      agreeToMarketing: !!base.agreeToMarketing,
+      fullName: base.nickname, // 이름 입력 UI가 따로 있으면 그 값을 넣으세요
+      gender, // "MALE" | "FEMALE" | "OTHER"
+      birthDate, // "yyyy-MM-dd"
+      phoneNumber, // "010-1234-5678"
     };
 
     try {
       setIsSubmitting(true);
-      await axios.post("/api/v1/auth/signup", body);
+      await axios.post("/api/v1/auth/signup", body, {
+        headers: { Authorization: `Bearer ${preSignupToken}` }, // ✅ 임시 토큰 필수
+        withCredentials: true,
+      });
+
+      // 가입 성공 후 정리
       sessionStorage.removeItem("signupData");
+      sessionStorage.removeItem("preSignupToken");
       navigate("/login/email");
     } catch (err: any) {
+      const status = err?.response?.status;
       const msg =
         err?.response?.data?.message ||
-        "회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.";
+        (status === 401
+          ? "가입 유효 시간이 만료되었습니다. 처음부터 다시 시도해주세요."
+          : "회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.");
       setError(msg);
       console.error("Signup error:", err);
     } finally {
@@ -147,6 +342,7 @@ const SignupDetailsPage = () => {
             onChange={(e) => handleBirthChange(e.target.value)}
             className="w-full border-b border-gray-300 py-2 px-1 text-[18px] focus:outline-none"
             required
+            inputMode="numeric"
           />
         </div>
 
@@ -157,11 +353,12 @@ const SignupDetailsPage = () => {
           </label>
           <input
             type="text"
-            placeholder="010-1234-1234"
+            placeholder="010-1234-5678"
             value={phone}
             onChange={(e) => handlePhoneChange(e.target.value)}
             className="w-full border-b border-gray-300 py-2 px-1 text-[18px] focus:outline-none"
             required
+            inputMode="numeric"
           />
         </div>
 
@@ -179,4 +376,4 @@ const SignupDetailsPage = () => {
   );
 };
 
-export default SignupDetailsPage;
+export default DesktopEmailSignupDetailPage;

--- a/src/pages/auth/SocialCallback.tsx
+++ b/src/pages/auth/SocialCallback.tsx
@@ -1,3 +1,131 @@
+// import { useEffect, useMemo } from "react";
+// import { useNavigate, useSearchParams } from "react-router-dom";
+
+// function parseHashParams(hash: string) {
+//   const h = hash.startsWith("#") ? hash.slice(1) : hash;
+//   return new URLSearchParams(h);
+// }
+
+// export default function SocialCallback() {
+//   const [params] = useSearchParams();
+//   const navigate = useNavigate();
+
+//   const query = useMemo(() => {
+//     const isNew = (params.get("isNew") ?? "").toLowerCase() === "true";
+//     const provider = params.get("provider") ?? "";
+//     const providerId = params.get("providerId") ?? "";
+//     const email = params.get("email") ?? "";
+//     const fullName = params.get("fullName") ?? "";
+
+//     // 임시 토큰은 쿼리 우선, 없으면 fragment에서 조회
+//     const hashParams = parseHashParams(window.location.hash);
+//     const signupToken =
+//       params.get("signupToken") ??
+//       params.get("socialTempToken") ??
+//       params.get("tempToken") ??
+//       hashParams.get("signupToken") ??
+//       hashParams.get("socialTempToken") ??
+//       hashParams.get("tempToken") ??
+//       "";
+
+//     const at = params.get("accessToken") ?? "";
+//     const rt = params.get("refreshToken") ?? "";
+//     const next = params.get("next") ?? "";
+//     return {
+//       isNew,
+//       provider,
+//       providerId,
+//       email,
+//       fullName,
+//       signupToken,
+//       at,
+//       rt,
+//       next,
+//     };
+//   }, [params]);
+
+//   useEffect(() => {
+//     const {
+//       isNew,
+//       provider,
+//       providerId,
+//       email,
+//       fullName,
+//       signupToken,
+//       at,
+//       rt,
+//       next,
+//     } = query;
+
+//     // URL에서 토큰 흔적 제거
+//     let cleaned = false;
+//     if (window.location.hash) {
+//       history.replaceState(
+//         null,
+//         "",
+//         window.location.pathname + window.location.search
+//       );
+//       cleaned = true;
+//     }
+//     if (
+//       !cleaned &&
+//       (params.get("signupToken") ||
+//         params.get("socialTempToken") ||
+//         params.get("tempToken"))
+//     ) {
+//       const u = new URL(window.location.href);
+//       u.searchParams.delete("signupToken");
+//       u.searchParams.delete("socialTempToken");
+//       u.searchParams.delete("tempToken");
+//       history.replaceState(
+//         null,
+//         "",
+//         u.pathname + (u.search ? "?" + u.searchParams.toString() : "")
+//       );
+//     }
+
+//     // 기존 유저: access/refresh 둘 다 있으면 바로 로그인
+//     if (!isNew && at && rt) {
+//       saveTokens(at, rt);
+//       const safeNext = next?.startsWith("/") ? next : "/";
+//       navigate(safeNext, { replace: true });
+//       return;
+//     }
+
+//     // 신규 유저: isNew가 없어도 임시 토큰이 있으면 신규 플로우로 보냄
+//     if ((isNew || !at) && signupToken) {
+//       navigate("/social-signup", {
+//         replace: true,
+//         state: {
+//           socialTempToken: signupToken,
+//           provider,
+//           providerId,
+//           email,
+//           fullName,
+//           next,
+//         },
+//       });
+//       return;
+//     }
+
+//     // 값 전달 방식(임시 토큰 없이 기본값만 온 경우)
+//     if (isNew && provider && providerId && email) {
+//       navigate("/social-signup", {
+//         replace: true,
+//         state: { provider, providerId, email, fullName, next },
+//       });
+//       return;
+//     }
+
+//     // 실패 시 로그인으로 회수
+//     clearTokens?.();
+//     navigate("/login?error=callback_mismatch", { replace: true });
+//   }, [navigate, query, params]);
+
+//   return <div className="p-6 text-center text-gray-600">로그인 처리 중...</div>;
+// }
+
+// src/pages/auth/SocialCallback.tsx
 import { useEffect, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
@@ -17,7 +145,7 @@ export default function SocialCallback() {
     const email = params.get("email") ?? "";
     const fullName = params.get("fullName") ?? "";
 
-    // 임시 토큰은 쿼리 우선, 없으면 fragment에서 조회
+    // 임시 토큰: 쿼리 > 해시(fragment) 우선순위
     const hashParams = parseHashParams(window.location.hash);
     const signupToken =
       params.get("signupToken") ??
@@ -30,7 +158,8 @@ export default function SocialCallback() {
 
     const at = params.get("accessToken") ?? "";
     const rt = params.get("refreshToken") ?? "";
-    const next = params.get("next") ?? "";
+    const next = params.get("next") ?? "/";
+
     return {
       isNew,
       provider,
@@ -57,7 +186,7 @@ export default function SocialCallback() {
       next,
     } = query;
 
-    // URL에서 토큰 흔적 제거
+    // URL에서 토큰 흔적 제거 (hash / query)
     let cleaned = false;
     if (window.location.hash) {
       history.replaceState(
@@ -80,19 +209,20 @@ export default function SocialCallback() {
       history.replaceState(
         null,
         "",
-        u.pathname + (u.search ? "?" + u.searchParams.toString() : "")
+        u.pathname + (u.search ? `?${u.searchParams.toString()}` : "")
       );
     }
 
     // 기존 유저: access/refresh 둘 다 있으면 바로 로그인
     if (!isNew && at && rt) {
-      saveTokens(at, rt);
+      localStorage.setItem("accessToken", at);
+      localStorage.setItem("refreshToken", rt);
       const safeNext = next?.startsWith("/") ? next : "/";
       navigate(safeNext, { replace: true });
       return;
     }
 
-    // 신규 유저: isNew가 없어도 임시 토큰이 있으면 신규 플로우로 보냄
+    // 신규 유저: isNew 이거나 accessToken이 없고 임시 토큰이 있으면 가입 플로우
     if ((isNew || !at) && signupToken) {
       navigate("/social-signup", {
         replace: true,
@@ -108,7 +238,7 @@ export default function SocialCallback() {
       return;
     }
 
-    // 값 전달 방식(임시 토큰 없이 기본값만 온 경우)
+    // 값 전달 방식 B: isNew + 핵심 식별자만 온 경우
     if (isNew && provider && providerId && email) {
       navigate("/social-signup", {
         replace: true,
@@ -117,11 +247,11 @@ export default function SocialCallback() {
       return;
     }
 
-    // 실패 시 로그인으로 회수
-    clearTokens?.();
+    // 실패 시 로그인으로 회수 (토큰 비우기)
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
     navigate("/login?error=callback_mismatch", { replace: true });
   }, [navigate, query, params]);
-
 
   return <div className="p-6 text-center text-gray-600">로그인 처리 중...</div>;
 }

--- a/src/utils/signup.ts
+++ b/src/utils/signup.ts
@@ -1,0 +1,22 @@
+export const PRE_SIGNUP_TOKEN_KEY = "preSignupToken";
+export const PRE_SIGNUP_DATA_KEY = "preSignupData";
+
+export const setPreSignupToken = (t: string) =>
+  sessionStorage.setItem(PRE_SIGNUP_TOKEN_KEY, t);
+export const getPreSignupToken = () =>
+  sessionStorage.getItem(PRE_SIGNUP_TOKEN_KEY);
+export const clearPreSignupToken = () =>
+  sessionStorage.removeItem(PRE_SIGNUP_TOKEN_KEY);
+
+export const setPreSignupData = (data: unknown) =>
+  sessionStorage.setItem(PRE_SIGNUP_DATA_KEY, JSON.stringify(data));
+export const getPreSignupData = <T = unknown>(): T | null => {
+  try {
+    const raw = sessionStorage.getItem(PRE_SIGNUP_DATA_KEY);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+};
+export const clearPreSignupData = () =>
+  sessionStorage.removeItem(PRE_SIGNUP_DATA_KEY);

--- a/src/utils/terms.ts
+++ b/src/utils/terms.ts
@@ -1,0 +1,40 @@
+// 서버 약관 타입(필요 시 프로젝트 공용 타입으로 이동)
+export type TermItem = {
+  id: number;
+  title: string;
+  required: boolean;
+  version?: string;
+  effectiveDate?: string;
+  content?: string; // HTML
+};
+
+// title 키워드로 우선 매칭 → 실패 시 fallback
+export function buildResolvedMap(terms?: TermItem[]) {
+  const all = terms ?? [];
+  const required = all.filter((t) => t.required);
+  const optional = all.filter((t) => !t.required);
+
+  const findBy = (kw: string) => all.find((t) => t.title?.includes(kw));
+
+  const map = {
+    terms: findBy("서비스 이용약관") ?? required[0], // 필수1
+    privacy: findBy("개인정보") ?? required[1] ?? required[0], // 필수2
+    marketing: findBy("마케팅") ?? optional[0] ?? all[0], // 선택1
+  } as const;
+
+  return map;
+}
+
+/** agrees 상태(terms/privacy/marketing) → agreedTermIds 계산 */
+export function resolveAgreedTermIds(
+  terms: TermItem[] | undefined,
+  agrees: { terms: boolean; privacy: boolean; marketing: boolean }
+) {
+  const map = buildResolvedMap(terms);
+  const ids: number[] = [];
+  if (agrees.terms && map.terms) ids.push(map.terms.id);
+  if (agrees.privacy && map.privacy) ids.push(map.privacy.id);
+  if (agrees.marketing && map.marketing) ids.push(map.marketing.id);
+  // 중복 제거
+  return Array.from(new Set(ids));
+}


### PR DESCRIPTION
## 📝 작업 개요

<!--무슨 작업을 했는지 요약-->

- 이메일 회원가입을 1·2단계 API로 분리하고 preSignupToken 발급 → 최종 회원가입까지 연동

## ✅ 작업 내용

- postPreSignup API 추가 (/api/v1/auth/pre-signup)
- PreSignupPayload 타입 정의
- API 응답에서 preSignupToken 추출 로직 추가
- postFinalSignup API 구현 (/api/v1/auth/signup)
- Authorization 헤더에 Bearer preSignupToken 적용