### PR TITLE
chore: add CI/CD (S3+CloudFront) deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy to S3 + CloudFront
+
+on:
+  push:
+    branches: ["dev"] # 필요하면 main 으로 변경
+  workflow_dispatch: # 수동 실행도 허용
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "deploy-dev"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      # 선택: CI에서 Vite ENV를 주입하고 싶으면 아래 사용
+      # VITE_SERVER_API_URL: ${{ secrets.VITE_SERVER_API_URL }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      S3_BUCKET: ${{ secrets.S3_BUCKET }}
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+        # env:
+        #   VITE_SERVER_API_URL: ${{ secrets.VITE_SERVER_API_URL }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload assets (long cache)
+        run: |
+          aws s3 sync ./dist "s3://${S3_BUCKET}" \
+            --exclude "index.html" \
+            --cache-control "public,max-age=31536000,immutable" \
+            --delete
+
+      - name: Upload index.html (no-cache)
+        run: |
+          aws s3 cp ./dist/index.html "s3://${S3_BUCKET}/index.html" \
+            --cache-control "no-cache" \
+            --content-type "text/html; charset=utf-8"
+
+      - name: Create CloudFront invalidation
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths "/*"


### PR DESCRIPTION
## 📝 작업 개요
GitHub Actions 기반 **CI/CD 파이프라인** 추가.  
`dev` 브랜치에 머지되면 자동으로 **빌드 → S3 업로드 → CloudFront 캐시 무효화**가 수행
- 워크플로 파일: `.github/workflows/deploy.yml`


---

## ✅ 작업 내용
- GitHub Actions 워크플로 추가
  - Node 20 + pnpm 설치, `pnpm install --frozen-lockfile` 후 `pnpm run build`
  - `dist/` 업로드
    - 정적 자산(JS/CSS/이미지): `public, max-age=31536000, immutable`
    - `index.html`: `no-cache`
  - CloudFront `/*` 무효화
- 배포 트리거: `push` to `dev` + 수동 실행(`workflow_dispatch`) 지원
- Secrets 참조

---

## 🔍 테스트 방법
1. 이 브랜치를 `dev`에 **PR 머지**
2. GitHub → **Actions**에서 `Deploy to S3 + CloudFront` 워크플로 성공 확인
3. 배포 URL 접속 후 **강력 새로고침(⌘+Shift+R)**
4. DevTools → **Network**
   - `index.html` 응답 헤더: `Cache-Control: no-cache`
   - 번들(JS/CSS) 헤더: `Cache-Control: public, max-age=31536000, immutable`
5. API 요청이 **`https://vita-check.com/...`** 로 가는지 확인

---

## 🧪 로컬 검증(선택)
```bash
pnpm run build
# dist 생성 확인
