### PR TITLE
chore: set start_url and scope to \"/\" for correct SPA entry

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,11 @@
       "src": "/icons/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
+    },
+    {
+      "start_url": "/",
+      "scope": "/",
+      "display": "standalone"
     }
   ]
 }


### PR DESCRIPTION
## 📝 작업 개요

<!--무슨 작업을 했는지 요약-->

- PWA 첫 진입 경로(/) 보장

## ✅ 작업 내용

- public/manifest.json
 - start_url을 /로 변경
 - scope를 /로 지정

