### PR TITLE
feat: 서비스 이용약관/개인정보 처리방침을 새 페이지에서 조회 가능하도록 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 // OAuth 리다이렉트
 import OauthRedirect from "./pages/auth/OauthRedirect"; // 소셜 로그인 리다이렉트 처리
 
+import TermsViewPage from "./pages/terms/TermsViewPage";
+
 // React Query 클라이언트 생성
 const queryClient = new QueryClient();
 
@@ -127,6 +129,11 @@ const router = createBrowserRouter([
       {
         path: "/ingredients/:ingredientName",
         element: <IngredientDetailPage />,
+      },
+
+      {
+        path: "/terms/:slug", // privacy | service | marketing
+        element: <TermsViewPage />,
       },
     ],
   },

--- a/src/apis/terms.ts
+++ b/src/apis/terms.ts
@@ -1,6 +1,8 @@
+// src/apis/terms.ts
 import axios from "@/lib/axios";
 import { useQuery } from "@tanstack/react-query";
 import type { UseQueryResult } from "@tanstack/react-query";
+import { useMemo } from "react";
 
 // ==== Types ====
 export interface Term {
@@ -50,3 +52,19 @@ export const useTerms = (): UseQueryResult<Term[], Error> =>
  *   </section>
  * ))
  */
+
+//  개인정보 처리방침만 골라주는 훅
+export const usePrivacyPolicy = () => {
+  const q = useTerms();
+  const term = useMemo(() => {
+    const list = q.data ?? [];
+    const byTitle = list.find((t) => t.title?.includes("개인정보"));
+    if (byTitle) return byTitle;
+
+    // fallback: required 중 두 번째 → 첫 번째 → 아무거나
+    const required = list.filter((t) => t.required);
+    return required[1] ?? required[0] ?? list[0];
+  }, [q.data]);
+
+  return { ...q, term };
+};

--- a/src/pages/terms/TermsViewPage.tsx
+++ b/src/pages/terms/TermsViewPage.tsx
@@ -1,0 +1,71 @@
+import React, { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { useTerms, type Term } from "@/apis/terms";
+
+type Slug = "privacy" | "service" | "marketing";
+
+/** 슬러그 기준으로 약관 선택 */
+function pickTermBySlug(list: Term[], slug: Slug): Term | undefined {
+  const find = (kw: string) => list.find((t) => t.title?.includes(kw));
+
+  switch (slug) {
+    case "privacy":
+      return find("개인정보") || list.filter((t) => t.required)[1] || list[0];
+    case "service":
+      return (
+        find("이용약관") ||
+        find("서비스") ||
+        list.filter((t) => t.required)[0] ||
+        list[0]
+      );
+    case "marketing":
+      return find("마케팅") || list.find((t) => !t.required) || list[0];
+    default:
+      return list[0];
+  }
+}
+
+const TermsViewPage: React.FC = () => {
+  const { slug = "privacy" } = useParams<{ slug: Slug }>();
+  const { data: terms, isLoading, error } = useTerms();
+
+  const picked = useMemo(
+    () =>
+      terms && terms.length ? pickTermBySlug(terms, slug as Slug) : undefined,
+    [terms, slug]
+  );
+
+  if (isLoading) return <main className="p-6">약관을 불러오는 중...</main>;
+  if (error)
+    return (
+      <main className="p-6 text-red-500">
+        약관 조회 중 오류가 발생했습니다.
+      </main>
+    );
+  if (!picked) return <main className="p-6">표시할 약관이 없습니다.</main>;
+
+  const pageTitle =
+    slug === "privacy"
+      ? "개인정보 처리방침"
+      : slug === "service"
+        ? "서비스 이용약관"
+        : "마케팅 이용 동의";
+
+  return (
+    <main className="mx-auto w-full max-w-3xl p-6">
+      <header className="mb-4">
+        <h1 className="text-2xl font-semibold">{pageTitle}</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          {picked.title} · 버전 {picked.version} · 시행일 {picked.effectiveDate}
+        </p>
+      </header>
+
+      <article
+        className="prose max-w-none"
+        dangerouslySetInnerHTML={{ __html: picked.content }}
+      />
+    </main>
+  );
+};
+
+export default TermsViewPage;


### PR DESCRIPTION
## 📝 작업 개요

<!--무슨 작업을 했는지 요약-->

- 마이페이지 내 서비스 이용약관/개인정보 처리방침 메뉴 클릭 시 모달이 아닌 새로운 페이지에서 해당 약관을 표시하도록 수정

## ✅ 작업 내용

- TermsViewPage 페이지 컴포넌트 신규 추가 (/terms/:slug 경로 대응)
- 약관 데이터(GET /api/v1/terms)에서 slug 기준으로 해당 약관만 선택해 표시
- 라우터에 /terms/service, /terms/privacy 경로 추가
- 마이페이지 메뉴 항목 클릭 시 navigate로 각 약관 페이지로 이동하도록 수정
