### PR TITLE
feat: 웹 푸시(Firebase) 연동 — SW/토큰 업서트/수신 및 /alarm 라우팅

### DIFF
--- a/src/components/FcmBootstrap.tsx
+++ b/src/components/FcmBootstrap.tsx
@@ -1,0 +1,51 @@
+// src/components/FcmBootstrap.tsx
+import { useEffect } from "react";
+import { registerServiceWorker, getFcmToken } from "@/lib/firebase";
+import { onForegroundMessage } from "@/lib/firebase";
+
+/**
+ * 역할:
+ *  1) 앱 부팅 시 서비스워커 등록
+ *  2) 권한이 이미 'granted'면 현재 토큰을 디버그로만 노출
+ *     (서버 동기화는 App.tsx의 syncFcmToken, 또는 설정 페이지의 enableWebPush에서 처리)
+ */
+export default function FcmBootstrap() {
+  useEffect(() => {
+    (async () => {
+      try {
+        await registerServiceWorker();
+
+        if (
+          typeof Notification !== "undefined" &&
+          Notification.permission === "granted"
+        ) {
+          const token = await getFcmToken();
+          // @ts-ignore
+          window.__fcmDebug = { token, permission: Notification.permission };
+        } else {
+          // @ts-ignore
+          window.__fcmDebug = {
+            token: null,
+            permission: Notification.permission,
+          };
+        }
+      } catch (e) {
+        // @ts-ignore
+        window.__fcmDebug = { error: String(e) };
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    onForegroundMessage(async (payload) => {
+      console.log("[PUSH][FG] payload", payload);
+      const title = payload?.notification?.title || "알림";
+      const body = payload?.notification?.body || "메시지가 도착했어요.";
+      // 포그라운드에서도 OS 알림 강제로 띄우기
+      const reg = await navigator.serviceWorker.ready;
+      reg.showNotification(title, { body, data: { link: "/alarm" } });
+    });
+  }, []);
+
+  return null;
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -106,3 +106,5 @@ export async function removeFcmToken() {
     return false;
   }
 }
+// @ts-ignore
+window.__fcm = { registerServiceWorker, getFcmToken };

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,0 +1,183 @@
+// src/lib/push.ts
+import api from "@/lib/axios";
+import {
+  registerServiceWorker,
+  requestNotificationPermission,
+  getFcmToken,
+  onForegroundMessage,
+  removeFcmToken,
+} from "@/lib/firebase";
+
+/**
+ * LocalStorage keys
+ */
+const LS_FCM_TOKEN = "fcmToken"; // last known browser token
+const LS_FCM_TOKEN_SENT = "fcmTokenSent"; // last token successfully sent to server
+
+type EnableResult =
+  | { ok: true; token: string }
+  | {
+      ok: false;
+      reason:
+        | "unsupported"
+        | "sw_register_failed"
+        | "denied"
+        | "no_token"
+        | "server_error";
+      error?: unknown;
+    };
+
+/** 내부 유틸 */
+const getLS = (k: string) => {
+  try {
+    return localStorage.getItem(k);
+  } catch {
+    return null;
+  }
+};
+const setLS = (k: string, v: string) => {
+  try {
+    localStorage.setItem(k, v);
+  } catch {}
+};
+const delLS = (k: string) => {
+  try {
+    localStorage.removeItem(k);
+  } catch {}
+};
+
+/**
+ * 서버에 FCM 토큰 동기화
+ * - 백엔드 스펙: PUT /api/v1/users/me/fcm-token  { fcmToken: string }
+ */
+async function sendTokenToServer(token: string) {
+  await api.put(
+    "/api/v1/users/me/fcm-token",
+    { fcmToken: token },
+    { withCredentials: true }
+  );
+}
+
+/**
+ * 앱 시작 시 한 번 호출하거나, "알림 켜기" 버튼에서 호출
+ * - SW 등록 → 권한 요청 → 토큰 발급 → 서버 전송(변경 시)
+ */
+export async function enableWebPush(opts?: {
+  onMessage?: (payload: any) => void;
+  forceResend?: boolean;
+}): Promise<EnableResult> {
+  // 1) SW 지원/권한 API 지원 체크
+  if (!("serviceWorker" in navigator) || !("Notification" in window)) {
+    console.warn("[PUSH] unsupported environment");
+    return { ok: false, reason: "unsupported" };
+  }
+
+  // 2) SW 등록
+  try {
+    await registerServiceWorker();
+  } catch (e) {
+    console.error("[PUSH] service worker register failed", e);
+    return { ok: false, reason: "sw_register_failed", error: e };
+  }
+
+  // 3) 권한 요청
+  const perm = await requestNotificationPermission();
+  if (perm !== "granted") {
+    console.warn("[PUSH] notification permission:", perm);
+    return { ok: false, reason: "denied" };
+  }
+
+  // 4) 토큰 발급
+  const token = await getFcmToken();
+  if (!token) {
+    console.error("[PUSH] getFcmToken() returned null");
+    return { ok: false, reason: "no_token" };
+  }
+
+  // 5) 서버 동기화 (변경되었거나 forceResend인 경우에만)
+  const prevToken = getLS(LS_FCM_TOKEN);
+  const lastSent = getLS(LS_FCM_TOKEN_SENT);
+  const shouldSend = opts?.forceResend || token !== lastSent;
+
+  try {
+    if (shouldSend) {
+      await sendTokenToServer(token);
+      setLS(LS_FCM_TOKEN_SENT, token);
+    }
+    setLS(LS_FCM_TOKEN, token);
+  } catch (e) {
+    console.error("[PUSH] send token to server failed", e);
+    return { ok: false, reason: "server_error", error: e };
+  }
+
+  // 6) 포그라운드 수신 콜백(옵션)
+  if (opts?.onMessage) {
+    onForegroundMessage(opts.onMessage);
+  }
+
+  console.log("[PUSH] enabled with token:", token.slice(0, 12) + "…");
+  return { ok: true, token };
+}
+
+/**
+ * 앱 시작 시 주기적으로 호출해서 토큰 변경을 서버와 재동기화
+ * (VAPID 키 변경, 브라우저 갱신, SW 재설치 등으로 토큰이 바뀔 수 있음)
+ */
+export async function syncFcmToken(forceResend = false) {
+  if (!("serviceWorker" in navigator) || !("Notification" in window)) return;
+
+  // 권한이 없으면 서버에 비우는 정책을 쓴다면 여기서 처리
+  if (Notification.permission !== "granted") return;
+
+  const token = await getFcmToken();
+  if (!token) return;
+
+  const lastSent = getLS(LS_FCM_TOKEN_SENT);
+  if (forceResend || token !== lastSent) {
+    try {
+      await sendTokenToServer(token);
+      setLS(LS_FCM_TOKEN_SENT, token);
+    } catch (e) {
+      console.error("[PUSH] sync send failed", e);
+    }
+  }
+  setLS(LS_FCM_TOKEN, token);
+}
+
+/**
+ * 로그아웃/알림 해제 시 호출
+ * - 현재 백엔드 스펙상 DELETE가 없으므로 빈 문자열을 PUT해서 비활성화 신호로 사용
+ *   (가능하면 서버에 DELETE /fcm-token 추가 권장)
+ */
+export async function disableWebPush() {
+  try {
+    // 서버 비활성화
+    await sendTokenToServer("");
+  } catch (e) {
+    console.warn("[PUSH] server disable failed (continuing)", e);
+  }
+
+  // 클라이언트 토큰 제거
+  const ok = await removeFcmToken().catch(() => false);
+
+  // 로컬 상태 정리
+  delLS(LS_FCM_TOKEN);
+  delLS(LS_FCM_TOKEN_SENT);
+
+  console.log("[PUSH] disabled", { removedLocal: ok });
+}
+
+/**
+ * 디버그 도우미: 현재 상태 로그
+ */
+export function debugPushStatus() {
+  const state = {
+    permission:
+      typeof Notification !== "undefined" ? Notification.permission : "n/a",
+    swSupported: "serviceWorker" in navigator,
+    token: getLS(LS_FCM_TOKEN)?.slice(0, 20) ?? null,
+    tokenSent: getLS(LS_FCM_TOKEN_SENT)?.slice(0, 20) ?? null,
+  };
+  console.table(state);
+  return state;
+}

--- a/src/pages/alarm/MobileAlarmPage.tsx
+++ b/src/pages/alarm/MobileAlarmPage.tsx
@@ -90,7 +90,7 @@ const MobileAlarmPage = ({
       }),
       axios.get("/api/v1/notifications/records", {
         params: { date: ymd, tzOffset },
-      }),
+      }), // 존재하지 않는 API
     ]);
 
     // records → Map<routineId, isTaken>


### PR DESCRIPTION
## 📝 작업 개요

웹 푸시(Firebase Cloud Messaging)

* Service Worker 등록 및 백그라운드 수신
* 브라우저 토큰 발급/업서트
* 앱 시작·재진입 시 토큰 재동기화
* 알림 클릭 시 `/alarm` 라우팅

---

## ✅ 작업 내용

* `public/firebase-messaging-sw.js` 추가

  * `onBackgroundMessage` 수신 → OS 알림 표시
  * `notificationclick` → 기존 탭 포커스/라우팅 또는 새 창 오픈
* `src/lib/firebase.ts` 보강

  * `ensureMessaging`, `registerServiceWorker`, `getFcmToken`, `onForegroundMessage`, `deleteToken`
* `src/lib/push.ts` 추가

  * `enableWebPush()` : 권한 요청 → 토큰 발급 → **PUT /api/v1/users/me/fcm-token**
  * `syncFcmToken(force)` : 권한 허용 시 토큰 변경되면 조용히 재전송
  * `disableWebPush()` : 로그아웃/해제 시 서버 비활성화 + 로컬 삭제
* `src/App.tsx`

  * 페이지 로드/가시성 변경 시 `syncFcmToken(false)` 실행(중복 업서트 방지)
  * `FcmBootstrap`로 SW 등록·디버그 노출
* `src/pages/alarm/AlarmPage.tsx`

  * 권한 미허용 배너(“알림 켜기”) → `enableWebPush()` 호출
---


## 🧪 테스트 방법

1. **SW 확인**

   * `https://<도메인>/firebase-messaging-sw.js` 200
   * DevTools → Application → Service Workers → scope=`/`, **Update on reload** 체크
2. **권한 & 토큰 업서트**

   * `/alarm`에서 “알림 켜기” → 권한 허용
   * Network: `PUT /api/v1/users/me/fcm-token` 200 & Body `{"fcmToken":"..."}`
   * 콘솔: `window.__fcmDebug`로 토큰/권한 확인
3. **수신 테스트(콘솔 발송)**

   * Firebase 콘솔 → **Messaging → 새 캠페인 → 알림 → \[테스트 메시지]**
   * 토큰에 `window.__fcmDebug.token` 붙여넣기
   * (옵션) 맞춤 데이터 `link=/alarm` 또는 웹 옵션 링크 `https://<도메인>/alarm`
   * **포그라운드**: `[PUSH][FG] payload` 로그
   * **백그라운드/닫힘**: OS 알림 표시, 클릭 시 `/alarm` 이동
4. **재동기화/로그아웃**

   * 새로고침/탭 복귀 시 불필요한 추가 `PUT` 없음
   * 로그아웃 시 `disableWebPush()`로 서버/로컬 토큰 비활성화

---

## ⚠️ 주의 / 제한

* **오리진별 토큰**: `localhost` 토큰은 프로덕션에서 재발급 필요
* **Safari(iOS/macOS)**: FCM Web 미지원 → 지원 브라우저 안내
* **VAPID 회전 시**: 이전 토큰 무효 → 배포 후 `syncFcmToken(true)`로 재업서트 필요

---

## 🔄 롤백 플랜

* 프론트: 배너/토글 UI 비활성 + SW 제거(또는 빈 `onBackgroundMessage`)
* 서버: 스케줄러 중단, 토큰 테이블 무시/비활성화 플래그
