### PR TITLE
feat(auth): OauthRedirect에 소셜 로그인 완료 후 후처리 구조 정리

### DIFF
--- a/src/pages/auth/OauthRedirect.tsx
+++ b/src/pages/auth/OauthRedirect.tsx
@@ -1,40 +1,16 @@
-// import { useEffect } from "react";
-// import { useNavigate, useSearchParams } from "react-router-dom";
-// import { saveTokens } from "@/lib/auth";
-
-// export default function OauthRedirect() {
-//   const [params] = useSearchParams();
-//   const navigate = useNavigate();
-
-//   useEffect(() => {
-//     const at = params.get("accessToken");
-//     const rt = params.get("refreshToken");
-
-//     if (at && rt) {
-//       saveTokens(at, rt);
-//       navigate("/", { replace: true });
-//     } else {
-//       // 토큰이 없으면 로그인으로 회수
-//       navigate("/login?error=missing_token", { replace: true });
-//     }
-//   }, [navigate, params]);
-
-//   return <div className="p-6 text-center text-gray-600">로그인 처리 중...</div>;
-// }
-
 import { useEffect, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { saveTokens, clearTokens } from "@/lib/auth";
+import { syncFcmToken } from "@/lib/push"; // ✅ 추가
 
 export default function OauthRedirect() {
   const [params] = useSearchParams();
   const navigate = useNavigate();
 
-  // 쿼리를 스냅샷으로 고정 (의존성 안정)
   const query = useMemo(() => {
     const at = params.get("accessToken") ?? "";
     const rt = params.get("refreshToken") ?? "";
-    const next = params.get("next") ?? ""; // 선택: 백엔드가 붙여줄 수 있음
+    const next = params.get("next") ?? "";
     return { at, rt, next };
   }, [params]);
 
@@ -42,8 +18,17 @@ export default function OauthRedirect() {
     const { at, rt, next } = query;
 
     if (at && rt) {
+      // 1) 액세스/리프레시 토큰 저장
       saveTokens(at, rt);
-      // 안전한 내부 경로만 허용 (open redirect 방지)
+
+      // 2) ✅ 로그인 직후 FCM 토큰 강제 동기화(권한이 허용된 경우에만 서버로 PUT)
+      //    - await로 네비게이션을 막고 싶지 않다면 fire-and-forget로 호출
+      //    - 내부에서 permission !== 'granted'면 바로 return함
+      syncFcmToken(true).catch(() => {
+        /* noop: 실패해도 네비게이션 진행 */
+      });
+
+      // 3) 안전한 내부 경로만 허용 (open redirect 방지)
       const safeNext = next?.startsWith("/") ? next : "/";
       navigate(safeNext, { replace: true });
     } else {


### PR DESCRIPTION
## 📝 작업 개요

<!--무슨 작업을 했는지 요약-->

- OauthRedirect에서 액세스/리프레시 토큰 저장 직후 syncFcmToken(true)를 호출

---

## ✅ 작업 내용

* `src/pages/auth/OauthRedirect.tsx`

  * `saveTokens(at, rt)` 직후 **`syncFcmToken(true)` 호출** 추가
  * 권한이 `granted`인 경우 `{ fcmToken }`을 **PUT `/api/v1/users/me/fcm-token`** 으로 업서트
  * `next` 파라미터는 내부 경로만 허용(오픈 리다이렉트 방지)