### PR TITLE
feat: OauthRedirect에 FCM 동기화 로직 보강(SW 등록/지원 체크)

### DIFF
--- a/src/pages/auth/OauthRedirect.tsx
+++ b/src/pages/auth/OauthRedirect.tsx
@@ -1,7 +1,10 @@
+// src/pages/auth/OauthRedirect.tsx
 import { useEffect, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { saveTokens, clearTokens } from "@/lib/auth";
-import { syncFcmToken } from "@/lib/push"; // ✅ 추가
+import { syncFcmToken } from "@/lib/push";
+import { registerServiceWorker } from "@/lib/firebase";
+import { isSupported } from "firebase/messaging";
 
 export default function OauthRedirect() {
   const [params] = useSearchParams();
@@ -10,31 +13,44 @@ export default function OauthRedirect() {
   const query = useMemo(() => {
     const at = params.get("accessToken") ?? "";
     const rt = params.get("refreshToken") ?? "";
-    const next = params.get("next") ?? "";
+    const next = params.get("next") ?? "/";
     return { at, rt, next };
   }, [params]);
 
   useEffect(() => {
-    const { at, rt, next } = query;
+    (async () => {
+      const { at, rt, next } = query;
 
-    if (at && rt) {
-      // 1) 액세스/리프레시 토큰 저장
+      if (!at || !rt) {
+        clearTokens?.();
+        navigate("/login?error=missing_token", { replace: true });
+        return;
+      }
+
+      // 1) 로그인 세션 저장
       saveTokens(at, rt);
 
-      // 2) ✅ 로그인 직후 FCM 토큰 강제 동기화(권한이 허용된 경우에만 서버로 PUT)
-      //    - await로 네비게이션을 막고 싶지 않다면 fire-and-forget로 호출
-      //    - 내부에서 permission !== 'granted'면 바로 return함
-      syncFcmToken(true).catch(() => {
-        /* noop: 실패해도 네비게이션 진행 */
-      });
+      // 2) SW 등록 보장 (대기 필요 없음)
+      registerServiceWorker().catch(() => {});
 
-      // 3) 안전한 내부 경로만 허용 (open redirect 방지)
-      const safeNext = next?.startsWith("/") ? next : "/";
+      // 3) 지원 환경에서만 강제 동기화
+      try {
+        const ok = await isSupported(); // ← 여기서 안전 체크
+        if (
+          ok &&
+          typeof Notification !== "undefined" &&
+          Notification.permission === "granted"
+        ) {
+          await syncFcmToken(true); // PUT /api/v1/users/me/fcm-token
+        }
+      } catch {
+        // 조용히 무시 (메인 앱에서 재동기화됨)
+      }
+
+      // 4) 이동 (open redirect 방지)
+      const safeNext = next.startsWith("/") ? next : "/";
       navigate(safeNext, { replace: true });
-    } else {
-      clearTokens?.();
-      navigate("/login?error=missing_token", { replace: true });
-    }
+    })();
   }, [navigate, query]);
 
   return <div className="p-6 text-center text-gray-600">로그인 처리 중...</div>;


### PR DESCRIPTION
## 📝 작업 개요

- 소셜 로그인(OAuth Redirect) 이후에도 FCM 토큰이 정상적으로 발급·저장되도록 수정

## ✅ 작업 내용

- `OauthRedirect` 컴포넌트에서 `registerServiceWorker` 호출 추가
- `isSupported()` 체크 후 권한이 허용(granted)된 경우 `syncFcmToken(true)` 실행
- 소셜 로그인 직후 발생하던 `[FCM] messaging not available` 에러 해결
- 기존의 안전 리다이렉트(`safeNext`) 로직 유지
