### PR TITLE
fix: Firebase API Key 등 누락된 환경변수 주입으로 FCM 초기화 오류 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,13 @@ jobs:
           VITE_SERVER_API_URL: ${{ secrets.VITE_SERVER_API_URL }}
           VITE_CLOUDINARY_CLOUD_NAME: ${{ secrets.VITE_CLOUDINARY_CLOUD_NAME }}
           VITE_CLOUDINARY_UPLOAD_PRESET: ${{ secrets.VITE_CLOUDINARY_UPLOAD_PRESET }}
+          VITE_FB_API_KEY: ${{ secrets.VITE_FB_API_KEY }}
+          VITE_FB_AUTH_DOMAIN: ${{ secrets.VITE_FB_AUTH_DOMAIN }}
+          VITE_FB_PROJECT_ID: ${{ secrets.VITE_FB_PROJECT_ID }}
+          VITE_FB_STORAGE_BUCKET: ${{ secrets.VITE_FB_STORAGE_BUCKET }}
+          VITE_FB_MESSAGING_SENDER_ID: ${{ secrets.VITE_FB_MESSAGING_SENDER_ID }}
+          VITE_FB_APP_ID: ${{ secrets.VITE_FB_APP_ID }}
+          VITE_FB_VAPID_KEY: ${{ secrets.VITE_FB_VAPID_KEY }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,4 +1,4 @@
-// publics/firebase-messaging-sw.js
+// public/firebase-messaging-sw.js
 
 importScripts(
   "https://www.gstatic.com/firebasejs/10.12.4/firebase-app-compat.js"

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -108,3 +108,14 @@ export async function removeFcmToken() {
 }
 // @ts-ignore
 window.__fcm = { registerServiceWorker, getFcmToken };
+
+console.log("[ENV]", {
+  VITE_FB_API_KEY: import.meta.env.VITE_FB_API_KEY,
+  VITE_FB_VAPID_KEY: import.meta.env.VITE_FB_VAPID_KEY,
+});
+
+console.log(
+  "[ENV check]",
+  !!import.meta.env.VITE_FB_API_KEY,
+  !!import.meta.env.VITE_FB_VAPID_KEY
+);

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -51,11 +51,7 @@ const delLS = (k: string) => {
  * - 백엔드 스펙: PUT /api/v1/users/me/fcm-token  { fcmToken: string }
  */
 async function sendTokenToServer(token: string) {
-  await api.put(
-    "/api/v1/users/me/fcm-token",
-    { fcmToken: token },
-    { withCredentials: true }
-  );
+  await api.put("/api/v1/users/me/fcm-token", { fcmToken: token });
 }
 
 /**


### PR DESCRIPTION
## 📝 작업 개요

<!--무슨 작업을 했는지 요약-->

- GitHub Actions 빌드 시 Firebase 환경변수가 누락되어 FCM 초기화가 실패하는 문제 수정

## ✅ 작업 내용

- ci.yml 워크플로우의 Build 단계에 Firebase 관련 환경변수(VITE_FB_API_KEY, VITE_FB_VAPID_KEY 등) 추가

