### PR TITLE
fix: PWA 매니페스트 설정 수정 (start_url 및 scope 경로 정상화)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,25 +1,13 @@
 {
   "name": "VitaCheck",
   "short_name": "VitaCheck",
-  "start_url": ".",
+  "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#ffffff",
   "icons": [
-    {
-      "src": "/icons/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png"
-    },
-    {
-      "start_url": "/",
-      "scope": "/",
-      "display": "standalone"
-    }
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
   ]
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -108,14 +108,3 @@ export async function removeFcmToken() {
 }
 // @ts-ignore
 window.__fcm = { registerServiceWorker, getFcmToken };
-
-console.log("[ENV]", {
-  VITE_FB_API_KEY: import.meta.env.VITE_FB_API_KEY,
-  VITE_FB_VAPID_KEY: import.meta.env.VITE_FB_VAPID_KEY,
-});
-
-console.log(
-  "[ENV check]",
-  !!import.meta.env.VITE_FB_API_KEY,
-  !!import.meta.env.VITE_FB_VAPID_KEY
-);


### PR DESCRIPTION
## 📝 작업 개요

<!--무슨 작업을 했는지 요약-->

- PWA 매니페스트 설정 오류를 수정하여 iOS 웹앱 실행 시 잘못된 경로(/assets/)로 진입하는 문제 해결

## ✅ 작업 내용

- manifest.json에서 start_url을 . → /로 수정
- icons 배열 안에 잘못 들어가 있던 start_url, scope, display 속성을 상위 레벨로 이동