### PR TITLE
fix: TimePicker 모달 실행 시 배경 스크롤 잠금 처리

### DIFF
--- a/src/pages/alarm/TimePickerModal.tsx
+++ b/src/pages/alarm/TimePickerModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Picker from "react-mobile-picker";
 
 type PickerValue = { hour: string; minute: string };
@@ -28,9 +28,41 @@ const TimePickerModal = ({
     defaultValue ?? { hour: "09", minute: "00" }
   );
 
+  // ✅ 배경 스크롤 잠금 (iOS 포함 안전)
+  useEffect(() => {
+    const scrollY = window.scrollY || document.documentElement.scrollTop;
+    const originalStyle = {
+      position: document.body.style.position,
+      top: document.body.style.top,
+      left: document.body.style.left,
+      right: document.body.style.right,
+      overflowY: document.body.style.overflowY,
+      width: document.body.style.width,
+    };
+
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.left = "0";
+    document.body.style.right = "0";
+    document.body.style.width = "100%";
+    document.body.style.overflowY = "hidden";
+
+    return () => {
+      // 원복 + 원래 위치로 스크롤 복구
+      document.body.style.position = originalStyle.position;
+      document.body.style.top = originalStyle.top;
+      document.body.style.left = originalStyle.left;
+      document.body.style.right = originalStyle.right;
+      document.body.style.overflowY = originalStyle.overflowY;
+      document.body.style.width = originalStyle.width;
+
+      window.scrollTo(0, scrollY);
+    };
+  }, []);
+
   return (
     <div
-      className="fixed inset-0 bg-black/40 flex items-end z-[60]"
+      className="fixed inset-0 bg-black/40 flex items-end z-[60] overscroll-none"
       onClick={onClose}
     >
       <div
@@ -51,11 +83,15 @@ const TimePickerModal = ({
           </button>
         </div>
 
-        {/* 휠 피커 (스크린샷 스타일) */}
-        <div className="relative flex justify-center items-center w-full h-[180px]">
+        {/* 휠 피커 */}
+        <div className="relative flex justify-center items-center w-full h-[180px] overscroll-contain">
           {/* 선택 하이라이트 바 */}
           <div className="absolute top-1/2 -translate-y-1/2 w-full h-[36px] bg-[#F1F1F1] rounded-md z-0" />
-          <div className="relative z-10 flex gap-3">
+          <div
+            className="relative z-10 flex gap-3"
+            onWheel={(e) => e.stopPropagation()} // 데스크톱 휠 이벤트가 바깥 스크롤로 전파되는 것 방지
+            onTouchMove={(e) => e.stopPropagation()} // 모바일에서 스크롤 체이닝 최소화
+          >
             <Picker
               value={pickerValue}
               onChange={setPickerValue}


### PR DESCRIPTION
## 📝 작업 개요
TimePicker 모달이 열렸을 때 뒤 화면이 스크롤되는 문제를 해결하기 위해 배경 스크롤을 잠그는 기능 추가

## ✅ 작업 내용
- 모달 열릴 때 `body`를 `position: fixed`로 고정하여 스크롤 차단
- 모달 닫을 때 기존 스크롤 위치 복원
- iOS Safari 환경에서도 안정적으로 동작하도록 처리