### PR TITLE
iOS PWA Web Push 구독 디버그용 SettingPage 및 push-ios.ts 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,8 @@ import { syncFcmTokenAfterLoginSilently } from "@/lib/push"; // 앞서 준 가�
 
 import { fcmTokenStore } from "@/lib/fcmTokenStore";
 
+import SettingsPage from "./pages/SettingsPage";
+
 const queryClient = new QueryClient();
 
 const router = createBrowserRouter([
@@ -121,7 +123,9 @@ const router = createBrowserRouter([
         element: <IngredientDetailPage />,
       },
       { path: "/terms/:slug", element: <TermsViewPage /> }, // privacy | service | marketing
+      { path: "/settings", element: <SettingsPage /> }, 
     ],
+
   },
 ]);
 

--- a/src/lib/push-ios.ts
+++ b/src/lib/push-ios.ts
@@ -1,0 +1,48 @@
+// src/lib/push-ios.ts
+import axios from "@/lib/axios";
+
+const VAPID_PUBLIC_KEY = import.meta.env.VITE_FB_VAPID_KEY as string;
+
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) output[i] = raw.charCodeAt(i);
+  return output;
+}
+
+export function isStandalonePWA(): boolean {
+  // iOS: navigator.standalone, 크로스 브라우저: display-mode
+  // @ts-ignore
+  return !!(window.navigator.standalone || window.matchMedia?.("(display-mode: standalone)")?.matches);
+}
+
+export async function ensureIOSWebPushSubscription() {
+  if (!("serviceWorker" in navigator) || !("PushManager" in window)) return null;
+  if (!isStandalonePWA()) return null;
+
+  if (Notification.permission !== "granted") {
+    const p = await Notification.requestPermission();
+    if (p !== "granted") return null;
+  }
+
+  const reg = await navigator.serviceWorker.register("/firebase-messaging-sw.js", { scope: "/" });
+  const existing = await reg.pushManager.getSubscription();
+  if (existing) return existing;
+
+  const sub = await reg.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
+  });
+
+  await axios.post("/api/v1/push/subscribe", {
+    endpoint: sub.endpoint,
+    keys: sub.toJSON().keys,
+    platform: "ios-pwa",
+    origin: location.origin,
+    userAgent: navigator.userAgent,
+  });
+
+  return sub;
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { ensureIOSWebPushSubscription } from "@/lib/push-ios";
+
+export default function SettingsPage() {
+  async function debugIOSSubscribe() {
+    const sub = await ensureIOSWebPushSubscription();
+    if (!sub) { console.log("[IOS-PWA] subscribe failed"); return; }
+    const json = sub.toJSON();
+    console.log("[IOS-PWA] endpoint:", json.endpoint);
+    console.log("[IOS-PWA] keys:", json.keys);
+  }
+
+  return (
+    <div>
+      <h1>설정 페이지</h1>
+      {/* 디버그용 버튼 */}
+      <button
+        onClick={debugIOSSubscribe}
+        className="border px-4 py-2 rounded bg-gray-200"
+      >
+        iOS WebPush 구독 디버그
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 작업 개요

- iOS PWA 환경에서 Web Push 구독 여부와 endpoint 확인을 위해
  SettingPage에 디버그 버튼을 추가하고, push-ios.ts 유틸 파일을 구현했습니다.

## ✅ 작업 내용

- src/lib/push-ios.ts 생성
  - ensureIOSWebPushSubscription() 구현
  - iOS PWA 전용 Web Push 구독 로직 추가
- SettingPage.tsx 수정
  - iOS Web Push 구독 디버그 버튼 추가
  - 버튼 클릭 시 endpoint와 키 값을 콘솔 출력
