### PR TITLE
feat:성분페이지 로그인 전 연령별 성분 & 권장량 그래프 & 영양제 페이지 제품 카드 크기 수정

### DIFF
--- a/src/components/ingredient/IngredientInfo.tsx
+++ b/src/components/ingredient/IngredientInfo.tsx
@@ -12,7 +12,6 @@ const IngredientInfo = ({ id, data }: Props) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
 
-  // 로그인 상태 및 사용자 프로필 확인
   useEffect(() => {
     const token = localStorage.getItem("accessToken");
     if (token) {
@@ -35,14 +34,6 @@ const IngredientInfo = ({ id, data }: Props) => {
     }
   };
 
-  // 디버깅 로그 (필요시 유지)
-  useEffect(() => {
-    console.log("=== IngredientInfo 데이터 디버깅 ===");
-    console.log("data:", data);
-    console.log("================================");
-  }, [data]);
-
-  // 에러 코드 메시지
   const getDosageErrorMessage = (errorCode?: string): string => {
     switch (errorCode) {
       case "UNAUTHORIZED":
@@ -56,19 +47,8 @@ const IngredientInfo = ({ id, data }: Props) => {
     }
   };
 
-  const getFoodErrorMessage = (errorCode?: string): string => {
-    switch (errorCode) {
-      case "INGREDIENT_FOOD_NOT_FOUND":
-        return "해당 성분의 대체 식품 정보가 없습니다.";
-      default:
-        return "";
-    }
-  };
-
-  // 섹션 표시는 항상
   const canShowDosageSection = () => true;
 
-  // 유효 데이터(둘 다 존재) - 0도 유효값으로 인정 => != null 사용
   const hasValidDosageData = () =>
     !data.dosageErrorCode &&
     data.gender &&
@@ -76,7 +56,6 @@ const IngredientInfo = ({ id, data }: Props) => {
     data.upperLimit != null &&
     data.recommendedDosage != null;
 
-  // 부분 데이터(하나만 존재)
   const hasPartialDosageData = () =>
     data.dosageErrorCode === "INGREDIENT_DOSAGE_HAVE_NULL" &&
     (data.recommendedDosage != null || data.upperLimit != null);
@@ -87,7 +66,6 @@ const IngredientInfo = ({ id, data }: Props) => {
   const isUnauthorized = data.dosageErrorCode === "UNAUTHORIZED";
   const isNotFound = data.dosageErrorCode === "INGREDIENT_DOSAGE_NOT_FOUND";
 
-  // 나이/성별 표기
   const getAgeGroup = (age: number): string => {
     if (age < 20) return "10대";
     if (age < 30) return "20대";
@@ -96,22 +74,14 @@ const IngredientInfo = ({ id, data }: Props) => {
     if (age < 60) return "50대";
     return "60대 이상";
   };
+
   const getGenderText = (gender: string): string =>
     gender === "MALE" ? "남성" : "여성";
 
   if (!id) return <div className="px-5 py-10">잘못된 접근입니다.</div>;
 
-  // 값 표시 유틸: null/undefined만 회색 null, 0은 정상 출력
-  const renderValue = (val: number | null | undefined, unit?: string) =>
-    val == null ? (
-      <span className="text-gray-400 italic">null</span>
-    ) : (
-      `${val}${unit || "mg"}`
-    );
-
   return (
     <div className="space-y-8 w-full px-4 sm:px-6 lg:px-8 mt-6">
-      {/* 이름 + 설명 */}
       <section>
         <h2 className="font-semibold text-2xl mb-4">
           {data.name && data.name !== "NULL" && data.name !== "null"
@@ -127,7 +97,6 @@ const IngredientInfo = ({ id, data }: Props) => {
         </p>
       </section>
 
-      {/* 효능 */}
       <section>
         <h2 className="font-semibold text-2xl pb-2">효능</h2>
         <p className="text-sm">
@@ -138,7 +107,6 @@ const IngredientInfo = ({ id, data }: Props) => {
         <div className="mt-4 border-b border-gray-300"></div>
       </section>
 
-      {/* 부작용 및 주의사항 */}
       <section>
         <h2 className="font-semibold text-2xl mb-2">부작용 및 주의사항</h2>
         <div className="flex items-start gap-4">
@@ -150,19 +118,12 @@ const IngredientInfo = ({ id, data }: Props) => {
             />
           </div>
           <div className="flex-1">
-            {(() => {
-              const cautionValue = data.caution;
-              if (
-                !cautionValue ||
-                cautionValue.trim().toLowerCase() === "null" ||
-                cautionValue.trim() === "" ||
-                cautionValue.trim().toLowerCase() === "undefined"
-              ) {
-                return null;
-              }
-              return (
+            {data.caution &&
+              !["", "null", "undefined"].includes(
+                data.caution.trim().toLowerCase()
+              ) && (
                 <div className="space-y-1">
-                  {cautionValue
+                  {data.caution
                     .split(
                       /(?=\(가\)|\(나\)|\(다\)|\(라\)|\(마\)|\(바\)|\(사\)|\(아\)|\(자\)|\(차\))/g
                     )
@@ -172,13 +133,11 @@ const IngredientInfo = ({ id, data }: Props) => {
                       </p>
                     ))}
                 </div>
-              );
-            })()}
+              )}
           </div>
         </div>
       </section>
 
-      {/* 권장 섭취량 */}
       {canShowDosageSection() && (
         <section>
           <h2 className="font-semibold text-2xl">
@@ -189,123 +148,174 @@ const IngredientInfo = ({ id, data }: Props) => {
               : "권장 섭취량"}
           </h2>
 
-          {/* 에러 메시지(로그인 후만 노출) */}
-          {data.dosageErrorCode && isLoggedIn && (
-            <div className="mt-3 p-4 bg-red-50 border border-red-200 rounded-lg">
-              <p className="text-red-700 text-sm">
-                {getDosageErrorMessage(data.dosageErrorCode)}
-              </p>
-            </div>
-          )}
+          {data.dosageErrorCode &&
+            isLoggedIn &&
+            data.dosageErrorCode !== "INGREDIENT_DOSAGE_NOT_FOUND" && (
+              <div className="mt-3 p-4 bg-red-50 border border-red-200 rounded-lg">
+                <p className="text-red-700 text-sm">
+                  {getDosageErrorMessage(data.dosageErrorCode)}
+                </p>
+              </div>
+            )}
 
-          {/* 로그인 미완료 → 블러 (PC: 제목 바로 밑 정렬/좌측 정렬, Mobile: 가운데) */}
           {!isLoggedIn ? (
             <div className="mt-3 md:mt-2">
-              {/* 그래프 전체를 클릭 가능하게 */}
               <Link to="/login" className="block">
                 <div className="relative w-full max-w-[400px] group cursor-pointer md:mx-0 mx-auto">
-                  {/* 그래프 박스(오버레이와 정확히 겹치도록 하나의 컨테이너) */}
                   <div className="relative h-8 w-full rounded-full overflow-hidden">
-                    {/* 배경 막대 */}
                     <div className="absolute inset-0 bg-gray-200" />
-                    {/* 채워진 막대(예시) */}
                     <div
                       className="absolute left-0 top-0 h-full bg-[#FFE17E]"
                       style={{ width: "66.67%" }}
                       aria-hidden
                     />
-                    {/* 블러/화이트 오버레이: 그래프와 정확히 일치 */}
                     <div className="absolute inset-0 bg-white/80 backdrop-blur-sm rounded-full pointer-events-none" />
-                    {/* 가운데 안내 문구 */}
                     <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
                       <p className="text-sm font-medium text-black">
                         로그인 후 확인해보세요!
                       </p>
                     </div>
-                    {/* 호버 테두리 효과(데스크톱만 느낌) */}
                     <div className="absolute inset-0 border-2 border-transparent rounded-full group-hover:border-blue-300 transition-colors duration-200 pointer-events-none" />
                   </div>
                 </div>
               </Link>
-
-              {/* 안내 문구: 그래프 '아래'에 배치 */}
               <div className="mt-2 w-full max-w-[400px] md:mx-33 mx-auto md:text-left text-center">
                 <p className="text-xs text-gray-600">
                   그래프 클릭하여 로그인하기
                 </p>
               </div>
             </div>
-          ) : isUnauthorized || isNotFound ? null : canShowDetailedDosage() ||
-            canShowPartialDosage() ? (
-            // 로그인 완료 & 데이터 존재(완전/부분 공통 그래프)
-            <div className="mt-8 md:mt-10">
-              <div className="relative w-full max-w-[400px] md:mx-0 mx-auto">
-                {/* 막대 */}
-                <div className="relative h-8 bg-gray-200 rounded-full overflow-hidden w-full">
-                  <div
-                    className="absolute left-0 top-0 bottom-0 bg-[#FFE17E] rounded-full"
-                    style={{ width: "66.67%" }}
-                    aria-hidden
-                  />
-                  {/* 마커 */}
-                  <div
-                    className="absolute top-0 bottom-0 border-l border-black border-dotted opacity-70"
-                    style={{ left: "33.33%" }}
-                    aria-hidden
-                  />
-                  <div
-                    className="absolute top-0 bottom-0 border-l border-black border-dotted opacity-70"
-                    style={{ left: "66.67%" }}
-                    aria-hidden
-                  />
-                </div>
+          ) : isUnauthorized ? null : (
+            (() => {
+              // dosageErrorCode에 따른 처리
+              if (data.dosageErrorCode === "INGREDIENT_DOSAGE_NOT_FOUND") {
+                // 해당 성분의 상한과 권장량 데이터 아예 없음
+                return (
+                  <div className="mt-8 md:mt-10">
+                    <div className="relative w-full max-w-[400px] md:mx-0 mx-auto">
+                      <div className="relative h-8 bg-gray-200 rounded-full overflow-hidden w-full">
+                        {/* 회색 바만 표시 (채움 0%) */}
+                      </div>
+                      <div className="text-center mt-4">
+                        <p className="text-gray-500 text-sm">
+                          해당 성분의 권장 섭취량 정보가 없습니다.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                );
+              }
 
-                {/* 라벨 */}
-                <div
-                  className="absolute text-sm font-medium text-black"
-                  style={{
-                    left: "33.33%",
-                    transform: "translateX(-50%)",
-                    top: "-24px",
-                  }}
-                >
-                  권장
-                </div>
-                <div
-                  className="absolute text-sm font-medium text-black"
-                  style={{
-                    left: "66.67%",
-                    transform: "translateX(-50%)",
-                    top: "-24px",
-                  }}
-                >
-                  상한
-                </div>
+              // 기존 로직 유지 (데이터가 잘 받아올 때)
+              const hasRec =
+                data.recommendedDosage != null && data.recommendedDosage !== 0;
+              const hasUpper = data.upperLimit != null && data.upperLimit !== 0;
+              const unit = data.unit || "mg";
 
-                {/* 수치 */}
-                <div
-                  className="absolute text-sm text-black"
-                  style={{
-                    left: "33.33%",
-                    transform: "translateX(-50%)",
-                    top: "40px",
-                  }}
-                >
-                  {renderValue(data.recommendedDosage, data.unit)}
+              // 노란색 바 너비 계산
+              let fillWidth = "0%";
+              if (hasRec && hasUpper) {
+                // 둘 다 있음: 기존과 동일하게 66.67%
+                fillWidth = "66.67%";
+              } else if (hasUpper) {
+                // 상한만 있음: 66.67%
+                fillWidth = "66.67%";
+              } else if (hasRec) {
+                // 권장만 있음: 33.33%
+                fillWidth = "33.33%";
+              }
+              // 둘 다 없음: 0% (회색 바만)
+
+              return (
+                <div className="mt-8 md:mt-10">
+                  <div className="relative w-full max-w-[400px] md:mx-0 mx-auto">
+                    <div className="relative h-8 bg-gray-200 rounded-full overflow-hidden w-full">
+                      {/* 노란색 바 */}
+                      <div
+                        className="absolute left-0 top-0 bottom-0 bg-[#FFE17E] rounded-full"
+                        style={{ width: fillWidth }}
+                        aria-hidden
+                      />
+
+                      {/* 권장 점선 - 권장 데이터가 있을 때만 표시 */}
+                      {hasRec && (
+                        <div
+                          className="absolute top-0 bottom-0 border-l border-black border-dotted opacity-70"
+                          style={{ left: "33.33%" }}
+                          aria-hidden
+                        />
+                      )}
+
+                      {/* 상한 점선 - 상한 데이터가 있을 때만 표시 */}
+                      {hasUpper && (
+                        <div
+                          className="absolute top-0 bottom-0 border-l border-black border-dotted opacity-70"
+                          style={{ left: "66.67%" }}
+                          aria-hidden
+                        />
+                      )}
+                    </div>
+
+                    {/* 권장 라벨 - 권장 데이터가 있을 때만 표시 */}
+                    {hasRec && (
+                      <div
+                        className="absolute text-sm font-medium text-black"
+                        style={{
+                          left: "33.33%",
+                          transform: "translateX(-50%)",
+                          top: "-24px",
+                        }}
+                      >
+                        권장
+                      </div>
+                    )}
+
+                    {/* 상한 라벨 - 상한 데이터가 있을 때만 표시 */}
+                    {hasUpper && (
+                      <div
+                        className="absolute text-sm font-medium text-black"
+                        style={{
+                          left: "66.67%",
+                          transform: "translateX(-50%)",
+                          top: "-24px",
+                        }}
+                      >
+                        상한
+                      </div>
+                    )}
+
+                    {/* 권장 수치 - 권장 데이터가 있을 때만 표시 */}
+                    {hasRec && (
+                      <div
+                        className="absolute text-sm text-black"
+                        style={{
+                          left: "33.33%",
+                          transform: "translateX(-50%)",
+                          top: "40px",
+                        }}
+                      >
+                        {`${data.recommendedDosage}${unit}`}
+                      </div>
+                    )}
+
+                    {/* 상한 수치 - 상한 데이터가 있을 때만 표시 */}
+                    {hasUpper && (
+                      <div
+                        className="absolute text-sm text-black"
+                        style={{
+                          left: "66.67%",
+                          transform: "translateX(-50%)",
+                          top: "40px",
+                        }}
+                      >
+                        {`${data.upperLimit}${unit}`}
+                      </div>
+                    )}
+                  </div>
                 </div>
-                <div
-                  className="absolute text-sm text-black"
-                  style={{
-                    left: "66.67%",
-                    transform: "translateX(-50%)",
-                    top: "40px",
-                  }}
-                >
-                  {renderValue(data.upperLimit, data.unit)}
-                </div>
-              </div>
-            </div>
-          ) : null}
+              );
+            })()
+          )}
         </section>
       )}
     </div>

--- a/src/components/ingredient/IngredientSupplements.tsx
+++ b/src/components/ingredient/IngredientSupplements.tsx
@@ -288,12 +288,22 @@ const IngredientSupplements = ({ data }: Props) => {
         </div>
       </section>
 
-      {/* 기존 ProductCard 그리드 UI 유지 */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-x-20 gap-y-6 md:gap-x-2">
+      {/* ProductCard 그리드 - 모바일에서는 검색바 너비에 맞춤 */}
+      <div
+        className={`grid ${
+          isMobile
+            ? "grid-cols-2 gap-x-2 gap-y-3 max-w-md mx-auto justify-items-center"
+            : "grid-cols-2 md:grid-cols-4 gap-x-2 gap-y-6"
+        }`}
+      >
         {filteredProducts.map((product, index) => (
           <div
             key={`${product.id}-${index}`}
-            className="flex justify-center"
+            className={`${
+              isMobile
+                ? "w-full transform scale-90 flex justify-center"
+                : "flex justify-center"
+            }`}
             ref={index === filteredProducts.length - 1 ? lastElementRef : null}
           >
             <ProductCard

--- a/src/pages/IngredientPage.tsx
+++ b/src/pages/IngredientPage.tsx
@@ -55,17 +55,10 @@ const IngredientPage = () => {
 
   // 인기성분 데이터 로드
   const loadPopularIngredients = async (ageGroup: string) => {
-    // 토큰이 없거나 유효하지 않은 경우 API 호출하지 않음
-    if (!token) {
-      console.log("🔥 [UI] 토큰이 없음 - 인기성분 로드 중단");
-      setPopularIngredients([]);
-      setIsLoadingPopular(false);
-      return;
-    }
-
     setIsLoadingPopular(true);
+
     try {
-      console.log("🔥 [UI] loadPopularIngredients 호출:", ageGroup);
+      console.log("🔥 [UI] 인기성분 API 호출 시작:", ageGroup);
 
       // 연령대별 파라미터 매핑 개선
       let apiAgeGroup: string = ageGroup;
@@ -91,25 +84,50 @@ const IngredientPage = () => {
       console.log("🔥 [UI] loadPopularIngredients 응답:", response);
 
       if (response && response.result) {
-        console.log("🔥 [UI] 인기성분 데이터 설정:", response.result);
-        setPopularIngredients(response.result);
+        // 새로운 API 응답 구조 처리: result.content 또는 result 배열
+        let ingredientsData = response.result;
+
+        // result.content가 있는 경우 (페이징 응답)
+        if (response.result.content && Array.isArray(response.result.content)) {
+          ingredientsData = response.result.content;
+        }
+        // result가 직접 배열인 경우
+        else if (Array.isArray(response.result)) {
+          ingredientsData = response.result;
+        }
+        // 둘 다 아닌 경우 빈 배열
+        else {
+          console.log("🔥 [UI] 응답 구조가 예상과 다름:", response.result);
+          ingredientsData = [];
+        }
+
+        console.log("🔥 [UI] 인기성분 데이터 설정:", ingredientsData);
+        setPopularIngredients(ingredientsData);
       } else {
         console.log("🔥 [UI] 응답에 result가 없음");
-        setPopularIngredients([]);
+        // 기본 성분 리스트 표시
+        const defaultIngredients = [
+          { id: 1, ingredientName: "비타민C" },
+          { id: 2, ingredientName: "오메가3" },
+          { id: 3, ingredientName: "프로바이오틱스" },
+          { id: 4, ingredientName: "마그네슘" },
+          { id: 5, ingredientName: "비타민D" },
+        ];
+        setPopularIngredients(defaultIngredients);
       }
     } catch (error: any) {
       console.error("🔥 [UI] 인기성분 로드 실패:", error);
 
-      // 401 에러가 발생하면 토큰이 유효하지 않다고 판단
-      if (error?.response?.status === 401) {
-        console.log("🔥 [UI] 401 에러 발생 - 토큰이 유효하지 않음");
-        // 토큰을 제거하고 로그인 상태를 false로 설정
-        localStorage.removeItem("accessToken");
-        localStorage.removeItem("refreshToken");
-        setPopularIngredients([]);
-      } else {
-        setPopularIngredients([]);
-      }
+      // API 호출 실패 시 기본 성분 리스트 표시
+      console.log("🔥 [UI] API 호출 실패 - 기본 성분 리스트 표시");
+      const defaultIngredients = [
+        { id: 1, ingredientName: "비타민C" },
+        { id: 2, ingredientName: "오메가3" },
+        { id: 3, ingredientName: "프로바이오틱스" },
+        { id: 4, ingredientName: "마그네슘" },
+        { id: 5, ingredientName: "비타민D" },
+      ];
+      setPopularIngredients(defaultIngredients);
     } finally {
       setIsLoadingPopular(false);
     }
@@ -133,11 +151,7 @@ const IngredientPage = () => {
 
   // 로그인 상태가 변경될 때마다 인기성분 다시 로드
   useEffect(() => {
-    if (isLoggedIn) {
-      loadPopularIngredients(selected);
-    } else {
-      setPopularIngredients([]);
-    }
+    loadPopularIngredients(selected);
   }, [isLoggedIn, selected]);
 
   const saveSearchHistory = (keyword: string) => {
@@ -172,10 +186,8 @@ const IngredientPage = () => {
   const handleChange = (age: string) => {
     setSelected(age);
     setShowAgeModal(false);
-    // 연령대 변경 시 새로운 인기성분 로드 (토큰이 있는 경우에만)
-    if (token) {
-      loadPopularIngredients(age);
-    }
+    // 연령대 변경 시 새로운 인기성분 로드
+    loadPopularIngredients(age);
   };
 
   const toggleAgeModal = () => {
@@ -532,16 +544,6 @@ const IngredientPage = () => {
               <span className="ml-3 text-gray-500">
                 인기성분을 불러오는 중...
               </span>
-            </div>
-          ) : !isLoggedIn ? (
-            <div className="text-center py-4">
-              <p className="text-gray-500 mb-5">로그인 후 이용할 수 있습니다</p>
-              <Link
-                to="/login"
-                className="inline-block px-4 py-2 bg-gray-300 text-white rounded-lg hover:bg-gray-400 transition-colors"
-              >
-                로그인하기
-              </Link>
             </div>
           ) : popularIngredients.length === 0 ? (
             <div className="text-center py-8">


### PR DESCRIPTION
## 📝 작업 개요

<!--무슨 작업을 했는지 요약-->
-성분페이지 로그인 전 연령별 성분 리스트 보이도록 수

-권장량 그래프에서 권장/상한 데이터 일부만 있을 경우에도 UI 정상 표시되도록 수정

-권장량 데이터가 모두 없을 경우에도 빈 회색 그래프만 출력되도록 처리

-영양제 리스트 카드 사이즈 반응형 개선

- close

## ✅ 작업 내용

-로그인 여부에 따라 그래프 UI 다르게 표시

-미로그인 시: 흐림 처리된 전체 그래프 + 로그인 유도 문구

-로그인 시:

-권장 + 상한 둘 다 있는 경우: 기본 그래프

-권장만 있는 경우: 권장 위치까지만 노란색 바 + 점선

-상한만 있는 경우: 상한 위치까지만 노란색 바 + 점선

-둘 다 없는 경우: 노란색 없이 회색 바만 표시

-점선 위치 및 텍스트 라벨 정렬 개선

-영양제 카드 높이 통일 및 반응형에서 깨지던 문제 수정

## 📸 스크린샷 (선택)

## 🔍 체크리스트 (선택)

- [ ] 디자인과 상의함
- [ ] 기능 정상 작동
