### PR TITLE
feat(combination-result): 섭취알림 버튼 반응형 동작 추가 — 모바일은 모달, 데스크탑은 페이지 이동

### DIFF
--- a/src/pages/combination/CombinationResultPage.tsx
+++ b/src/pages/combination/CombinationResultPage.tsx
@@ -1,13 +1,14 @@
-import { useState, useEffect, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import checkedBoxIcon from '../../assets/check box.png';
-import vitaminArrow from '../../assets/비타민 C_arrow.png';
-import boxIcon from '../../assets/box.png';
-import flipIcon from '../../assets/flip.png';
-import axios from '@/lib/axios';
-import Navbar from '@/components/NavBar';
-import line from '/images/PNG/조합 2-1/background line.png';
-import ShareLinkPopup from '@/components/combination/ShareLinkPopup' 
+import { useState, useEffect, useRef } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import checkedBoxIcon from "../../assets/check box.png";
+import vitaminArrow from "../../assets/비타민 C_arrow.png";
+import boxIcon from "../../assets/box.png";
+import flipIcon from "../../assets/flip.png";
+import axios from "@/lib/axios";
+import Navbar from "@/components/NavBar";
+import line from "/images/PNG/조합 2-1/background line.png";
+import ShareLinkPopup from "@/components/combination/ShareLinkPopup";
+import AlarmAddToSearchModal from "@/pages/alarm/AlarmAddToSearchModal";
 
 const KAKAO_TEMPLATE_ID = 123624; // 콘솔의 템플릿 ID
 
@@ -16,9 +17,9 @@ const useIsMobile = () => {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
   useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768);
-    window.addEventListener('resize', handleResize);
+    window.addEventListener("resize", handleResize);
     return () => {
-      window.removeEventListener('resize', handleResize);
+      window.removeEventListener("resize", handleResize);
     };
   }, []);
   return isMobile;
@@ -54,7 +55,7 @@ interface IngredientResult {
 
 interface Combination {
   id: number;
-  type: 'GOOD' | 'CAUTION';
+  type: "GOOD" | "CAUTION";
   name: string;
   description: string;
   displayRank: number;
@@ -78,7 +79,7 @@ export default function CombinationResultPage() {
 
   function calcGauge(ing: IngredientResult) {
     const total = ing.totalAmount ?? 0;
-    const unit = ing.unit ?? '';
+    const unit = ing.unit ?? "";
     const rec = ing.recommendedAmount;
     const upper = ing.upperAmount;
 
@@ -102,9 +103,11 @@ export default function CombinationResultPage() {
     const yellowWidth = hasRealRec ? Math.min(widthPct, recPct) : widthPct;
     const orangeLeft = hasRealRec ? recPct : null;
     const orangeRight = hasRealUpper ? Math.min(widthPct, upperPct) : widthPct;
-    const orangeWidth = orangeLeft != null ? Math.max(0, orangeRight - orangeLeft) : 0;
+    const orangeWidth =
+      orangeLeft != null ? Math.max(0, orangeRight - orangeLeft) : 0;
     const redLeft = hasRealUpper ? upperPct : null;
-    const redWidth = redLeft != null && widthPct > redLeft ? widthPct - redLeft : 0;
+    const redWidth =
+      redLeft != null && widthPct > redLeft ? widthPct - redLeft : 0;
 
     // 상한 초과 여부를 명확하게 계산
     // 상한선(66.67% 또는 실제 upper 값) 이상인 경우를 초과로 판단
@@ -138,7 +141,11 @@ export default function CombinationResultPage() {
 
     // 상한을 초과했을 때, 66.67%~100% 구간을 "초과량"에 비례해서 채우는 도우미
     // capMultiplier: 상한의 몇 배까지를 100%로 볼지 (예: 1.5배면 150%에서 막음)
-    const overMap = (totalVal: number, upperVal: number, capMultiplier = 1.5) => {
+    const overMap = (
+      totalVal: number,
+      upperVal: number,
+      capMultiplier = 1.5
+    ) => {
       const extra = Math.max(0, totalVal - upperVal); // 초과량
       const maxExtra = Math.max(upperVal * (capMultiplier - 1), 1e-6); // cap까지 초과량
       const t = Math.min(extra / maxExtra, 1); // 0..1
@@ -153,7 +160,10 @@ export default function CombinationResultPage() {
         }
         if (total <= upper) {
           const r = (total - rec) / Math.max(upper - rec, 1e-6);
-          return Math.max(0, Math.min(100, REC_LINE_POS + r * (UPPER_LINE_POS - REC_LINE_POS)));
+          return Math.max(
+            0,
+            Math.min(100, REC_LINE_POS + r * (UPPER_LINE_POS - REC_LINE_POS))
+          );
         }
         // ✅ 상한 초과: 66.67%~100% 구간으로 매핑
         return overMap(total, upper, 1.5); // cap 150% (원하면 1.3, 2.0 등으로 조절)
@@ -188,46 +198,58 @@ export default function CombinationResultPage() {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const selectedItems = location.state?.selectedItems || [];
-  console.log('selectedItems:', selectedItems);
-  console.log('location.state:', location.state);
+  console.log("selectedItems:", selectedItems);
+  console.log("location.state:", location.state);
   const [checkedIndices, setCheckedIndices] = useState<number[]>([]);
 
-  const [activeTab, setActiveTab] = useState<'전체' | '초과'>('전체');
+  const [activeTab, setActiveTab] = useState<"전체" | "초과">("전체");
   const [allOverUpper, setAllOverUpper] = useState(false);
   const [showAllIngredients, setShowAllIngredients] = useState(false);
 
-  const [ingredientResults, setIngredientResults] = useState<IngredientResult[]>([]);
+  const [ingredientResults, setIngredientResults] = useState<
+    IngredientResult[]
+  >([]);
 
   const [goodCombinations, setGoodCombinations] = useState<Combination[]>([]);
-  const [cautionCombinations, setCautionCombinations] = useState<Combination[]>([]);
-
+  const [cautionCombinations, setCautionCombinations] = useState<Combination[]>(
+    []
+  );
 
   // 공유 바텀시트/확인 모달
-const [setSheetOpen] = useState(false);
-const [setConfirmOpen] = useState(false);
+  const [setSheetOpen] = useState(false);
+  const [setConfirmOpen] = useState(false);
 
-const [shareOpen, setShareOpen] = useState(false);
-const shareUrl   = window.location.origin.includes("vitachecking.com") ? window.location.href : "https://vitachecking.com/combination-result";
-const shareImage = selectedItems?.[0]?.imageUrl ?? "https://vitachecking.com/static/share-default.png";
-const shareTitle = "내 영양제 조합 결과";
+  const [shareOpen, setShareOpen] = useState(false);
+  const shareUrl = window.location.origin.includes("vitachecking.com")
+    ? window.location.href
+    : "https://vitachecking.com/combination-result";
+  const shareImage =
+    selectedItems?.[0]?.imageUrl ??
+    "https://vitachecking.com/static/share-default.png";
+  const shareTitle = "내 영양제 조합 결과";
 
-// 템플릿 숫자: 초과/권장충족/주의조합
-const overCount = ingredientResults.filter(i => computeFillPercent(i) > UPPER_LINE_POS).length;
+  // 템플릿 숫자: 초과/권장충족/주의조합
+  const overCount = ingredientResults.filter(
+    (i) => computeFillPercent(i) > UPPER_LINE_POS
+  ).length;
 
-const metCount = ingredientResults.filter(i =>
-  (i.recommendedAmount ?? 0) > 0 && i.totalAmount >= (i.recommendedAmount ?? 0)
-).length;
+  const metCount = ingredientResults.filter(
+    (i) =>
+      (i.recommendedAmount ?? 0) > 0 &&
+      i.totalAmount >= (i.recommendedAmount ?? 0)
+  ).length;
 
-const cautionCount = cautionCombinations.length;
+  const cautionCount = cautionCombinations.length;
 
   const filteredIngredients: IngredientResult[] =
-    activeTab === '전체'
+    activeTab === "전체"
       ? ingredientResults
       : ingredientResults.filter((i) => {
           // 기존 계산
           const isOverRecommended = i.dosageRatio > 1;
           const isOverUpper = i.overRecommended;
-          const isOverUpperLimit = i.upperAmount && i.totalAmount > i.upperAmount;
+          const isOverUpperLimit =
+            i.upperAmount && i.totalAmount > i.upperAmount;
 
           // 게이지 기준(상한선 라인) 초과 체크
           const gauge = calcGauge(i);
@@ -241,14 +263,23 @@ const cautionCount = cautionCombinations.length;
           // (선택) 일반 기준치 예외 처리 유지
           let isOverGeneralLimit = false;
           if (i.recommendedAmount === null && i.upperAmount === null) {
-            if (i.unit === 'IU') {
-              if (i.ingredientName.includes('비타민 D') && i.totalAmount > 4000) {
+            if (i.unit === "IU") {
+              if (
+                i.ingredientName.includes("비타민 D") &&
+                i.totalAmount > 4000
+              ) {
                 isOverGeneralLimit = true;
-              } else if (i.ingredientName.includes('비타민 A') && i.totalAmount > 10000) {
+              } else if (
+                i.ingredientName.includes("비타민 A") &&
+                i.totalAmount > 10000
+              ) {
                 isOverGeneralLimit = true;
               }
-            } else if (i.unit === 'mg') {
-              if (i.ingredientName.includes('비타민 C') && i.totalAmount > 2000) {
+            } else if (i.unit === "mg") {
+              if (
+                i.ingredientName.includes("비타민 C") &&
+                i.totalAmount > 2000
+              ) {
                 isOverGeneralLimit = true;
               } else if (i.totalAmount > 1000) {
                 isOverGeneralLimit = true;
@@ -261,31 +292,37 @@ const cautionCount = cautionCombinations.length;
           return shouldShow;
         });
 
-
   const fetchCombinationResult = async () => {
     try {
       // supplementId가 있는 경우에만 필터링하여 사용
-      const validItems = selectedItems.filter((item: SupplementItem) => item.supplementId);
-      const supplementIds = validItems.map((item: SupplementItem) => item.supplementId!);
-      console.log('API 호출 시작 - supplementIds:', supplementIds);
-      console.log('selectedItems 전체:', selectedItems);
+      const validItems = selectedItems.filter(
+        (item: SupplementItem) => item.supplementId
+      );
+      const supplementIds = validItems.map(
+        (item: SupplementItem) => item.supplementId!
+      );
+      console.log("API 호출 시작 - supplementIds:", supplementIds);
+      console.log("selectedItems 전체:", selectedItems);
 
       if (supplementIds.length === 0) {
-        console.warn('분석 가능한 supplementId가 없습니다.');
+        console.warn("분석 가능한 supplementId가 없습니다.");
         setIngredientResults([]);
         return;
       }
 
-      const res = await axios.post('/api/v1/combinations/analyze', {
+      const res = await axios.post("/api/v1/combinations/analyze", {
         supplementIds,
       });
-      console.log('API 응답 전체:', res.data);
-      console.log('API 응답 result:', res.data.result);
-      console.log('API 응답 ingredientResults:', res.data.result?.ingredientResults);
+      console.log("API 응답 전체:", res.data);
+      console.log("API 응답 result:", res.data.result);
+      console.log(
+        "API 응답 ingredientResults:",
+        res.data.result?.ingredientResults
+      );
 
       if (res.data.result?.ingredientResults) {
         console.log(
-          '성분 결과 상세:',
+          "성분 결과 상세:",
           res.data.result.ingredientResults.map((i: any) => ({
             name: i.ingredientName,
             total: i.totalAmount,
@@ -293,26 +330,26 @@ const cautionCount = cautionCombinations.length;
             upper: i.upperAmount,
             ratio: i.dosageRatio,
             overRecommended: i.overRecommended,
-          })),
+          }))
         );
         setIngredientResults(res.data.result.ingredientResults);
       } else {
-        console.warn('ingredientResults가 없습니다:', res.data);
+        console.warn("ingredientResults가 없습니다:", res.data);
         setIngredientResults([]);
       }
     } catch (error) {
-      console.error('조합 결과 조회 실패:', error);
+      console.error("조합 결과 조회 실패:", error);
       setIngredientResults([]);
     }
   };
 
   const fetchCombinationRecommendations = async () => {
     try {
-      const res = await axios.get('/api/v1/combinations/recommend');
+      const res = await axios.get("/api/v1/combinations/recommend");
       setGoodCombinations(res.data.result.goodCombinations);
       setCautionCombinations(res.data.result.cautionCombinations);
     } catch (error) {
-      console.error('추천 조합 조회 실패:', error);
+      console.error("추천 조합 조회 실패:", error);
     }
   };
 
@@ -326,13 +363,13 @@ const cautionCount = cautionCombinations.length;
   // 모바일에서는 전역 헤더 숨김(있으면)
   useEffect(() => {
     if (!isMobile) return;
-    const headerEl = document.querySelector('header');
+    const headerEl = document.querySelector("header");
     if (headerEl instanceof HTMLElement) {
-      headerEl.style.display = 'none';
+      headerEl.style.display = "none";
     }
     return () => {
       if (headerEl instanceof HTMLElement) {
-        headerEl.style.display = '';
+        headerEl.style.display = "";
       }
     };
   }, [isMobile]);
@@ -344,37 +381,68 @@ const cautionCount = cautionCombinations.length;
 
   const alarmEnabled = checkedIndices.length === 1;
 
-  const handleScroll = (direction: 'left' | 'right') => {
+  // 모바일에서 섭취 알림 모달 열기
+  const [openAlarmModal, setOpenAlarmModal] = useState(false);
+
+  // 1개만 선택된 제품(버튼 활성 조건과 동일)
+  const selectedItem = selectedItems.find((it: SupplementItem) =>
+    checkedIndices.includes(it.cursorId)
+  );
+
+  // 버튼 핸들러들 근처에 추가
+  const handleAlarmClick = () => {
+    if (!alarmEnabled || !selectedItem) return;
+
+    if (isMobile) {
+      // 모바일: 모달 오픈
+      setOpenAlarmModal(true);
+    } else {
+      // 데스크탑: 페이지 이동 (supplementId 쿼리로 전달)
+      const id = selectedItem.supplementId ?? selectedItem.cursorId;
+      const q = new URLSearchParams({ supplementId: String(id) });
+      navigate(`/alarm/settings/add/search?${q.toString()}`);
+    }
+  };
+
+  const handleScroll = (direction: "left" | "right") => {
     const el = scrollRef.current;
     if (!el) return;
     const page = el.clientWidth; // 현재 보이는 영역 너비
-    const delta = direction === 'right' ? page : -page;
+    const delta = direction === "right" ? page : -page;
     let target = el.scrollLeft + delta;
     // 경계 보정
     target = Math.max(0, Math.min(target, el.scrollWidth - el.clientWidth));
-    el.scrollTo({ left: target, behavior: 'smooth' });
+    el.scrollTo({ left: target, behavior: "smooth" });
   };
 
   const handleToggleCheckbox = (cursorId: number) => {
     setCheckedIndices((prev) =>
-      prev.includes(cursorId) ? prev.filter((i) => i !== cursorId) : [...prev, cursorId],
+      prev.includes(cursorId)
+        ? prev.filter((i) => i !== cursorId)
+        : [...prev, cursorId]
     );
   };
 
   const handleRecombination = () => {
     const selectedFiltered = selectedItems.filter((item: SupplementItem) =>
-      checkedIndices.includes(item.cursorId),
+      checkedIndices.includes(item.cursorId)
     );
 
     // 선택된 아이템들의 이름을 검색어로 사용하여 검색 결과를 미리 보여주기
-    const searchTerms = selectedFiltered.map((item: SupplementItem) => item.supplementName);
+    const searchTerms = selectedFiltered.map(
+      (item: SupplementItem) => item.supplementName
+    );
 
     // 검색기록에 선택된 제품들의 이름을 추가
-    const currentHistory = JSON.parse(localStorage.getItem('searchHistory') || '[]');
-    const updatedHistory = [...new Set([...searchTerms, ...currentHistory])].slice(0, 10); // 중복 제거하고 최대 10개 유지
-    localStorage.setItem('searchHistory', JSON.stringify(updatedHistory));
+    const currentHistory = JSON.parse(
+      localStorage.getItem("searchHistory") || "[]"
+    );
+    const updatedHistory = [
+      ...new Set([...searchTerms, ...currentHistory]),
+    ].slice(0, 10); // 중복 제거하고 최대 10개 유지
+    localStorage.setItem("searchHistory", JSON.stringify(updatedHistory));
 
-    navigate('/add-combination', {
+    navigate("/add-combination", {
       state: {
         selectedItems: selectedFiltered,
         preSearchTerms: searchTerms, // 검색어들을 미리 전달
@@ -383,25 +451,28 @@ const cautionCount = cautionCombinations.length;
     });
   };
 
-  const FlipCard: React.FC<{ name: string; description: string }> = ({ name, description }) => {
+  const FlipCard: React.FC<{ name: string; description: string }> = ({
+    name,
+    description,
+  }) => {
     const [flipped, setFlipped] = useState(false);
     return (
       <>
         {/* 모바일 카드 */}
         <div
           className="block h-[135px] w-[150px] cursor-pointer md:hidden"
-          style={{ perspective: '1000px' }}
+          style={{ perspective: "1000px" }}
           onClick={() => setFlipped(!flipped)}
         >
           <div
             className={`relative h-full w-full transition-transform duration-500 ${
-              flipped ? 'rotate-y-180' : ''
+              flipped ? "rotate-y-180" : ""
             }`}
-            style={{ transformStyle: 'preserve-3d' }}
+            style={{ transformStyle: "preserve-3d" }}
           >
             <div
               className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-white px-[6px] py-[10px] text-center text-[18px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
-              style={{ backfaceVisibility: 'hidden' }}
+              style={{ backfaceVisibility: "hidden" }}
             >
               {name}
               <img
@@ -412,7 +483,10 @@ const cautionCount = cautionCombinations.length;
             </div>
             <div
               className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-[#FFFBCC] px-[6px] py-[10px] text-center text-[18px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
-              style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
+              style={{
+                backfaceVisibility: "hidden",
+                transform: "rotateY(180deg)",
+              }}
             >
               {description}
               <img
@@ -427,18 +501,18 @@ const cautionCount = cautionCombinations.length;
         {/* PC용 카드 */}
         <div
           className="hidden h-[165px] w-[235px] cursor-pointer md:block"
-          style={{ perspective: '1000px' }}
+          style={{ perspective: "1000px" }}
           onClick={() => setFlipped(!flipped)}
         >
           <div
             className={`relative h-full w-full transition-transform duration-500 ${
-              flipped ? 'rotate-y-180' : ''
+              flipped ? "rotate-y-180" : ""
             }`}
-            style={{ transformStyle: 'preserve-3d' }}
+            style={{ transformStyle: "preserve-3d" }}
           >
             <div
               className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-white px-[2px] py-[2px] text-center text-[20px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
-              style={{ backfaceVisibility: 'hidden' }}
+              style={{ backfaceVisibility: "hidden" }}
             >
               {name}
               <img
@@ -449,7 +523,10 @@ const cautionCount = cautionCombinations.length;
             </div>
             <div
               className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-[#FFFBCC] px-[6px] py-[10px] text-center text-[20px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
-              style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
+              style={{
+                backfaceVisibility: "hidden",
+                transform: "rotateY(180deg)",
+              }}
             >
               {description}
               <img
@@ -470,7 +547,6 @@ const cautionCount = cautionCombinations.length;
       <div className="md:hidden">
         <Navbar />
       </div>
-
       {/* 조합분석 - 모바일 (제목 + 아이콘들) */}
       <div className="mb-5 flex items-center justify-between pt-6 pr-2 pl-2 md:hidden">
         <h1 className="font-pretendard text-[24px] leading-[100%] font-bold tracking-[-0.02em]">
@@ -479,8 +555,13 @@ const cautionCount = cautionCombinations.length;
 
         <div className="flex items-center gap-3">
           {/* 공유 */}
-          <button type="button" aria-label="공유" className="active:scale-95" onClick={() => setShareOpen(true)}>
-          <img
+          <button
+            type="button"
+            aria-label="공유"
+            className="active:scale-95"
+            onClick={() => setShareOpen(true)}
+          >
+            <img
               src="/images/PNG/조합 3-1/공유.png"
               alt="공유"
               className="h-[35px] w-[35px] object-contain"
@@ -488,7 +569,11 @@ const cautionCount = cautionCombinations.length;
           </button>
 
           {/* 재조합 */}
-          <button type="button" className="m-0 p-0 leading-none" onClick={handleRecombination}>
+          <button
+            type="button"
+            className="m-0 p-0 leading-none"
+            onClick={handleRecombination}
+          >
             <img
               src="/images/PNG/조합 3-1/재조합.png"
               alt="재조합"
@@ -497,7 +582,6 @@ const cautionCount = cautionCombinations.length;
           </button>
         </div>
       </div>
-
       {/* PC 제목 + 버튼들 한 줄 배치 */}
       <div className="mb-8 hidden items-center justify-between px-8 md:flex">
         <h1 className="text-2xl font-semibold sm:text-4xl">조합 분석</h1>
@@ -509,25 +593,23 @@ const cautionCount = cautionCombinations.length;
             재조합
           </button>
           <button
-            onClick={() => {
-              if (!alarmEnabled) return; // 가드
-              navigate('/alarm/settings');
-            }}
+            onClick={handleAlarmClick}
             disabled={!alarmEnabled}
             aria-disabled={!alarmEnabled}
-            title={!alarmEnabled ? '제품을 1개만 선택해주세요' : '섭취알림 등록하기'}
+            title={
+              !alarmEnabled ? "제품을 1개만 선택해주세요" : "섭취알림 등록하기"
+            }
             className={[
-              'flex h-[55px] w-[280px] items-center justify-center rounded-[62.5px] font-bold transition',
+              "flex h-[55px] w-[280px] items-center justify-center rounded-[62.5px] font-bold transition",
               alarmEnabled
-                ? 'bg-[#FFEB9D] hover:brightness-95'
-                : 'cursor-not-allowed bg-[#EEEEEE] text-[#9C9A9A]',
-            ].join(' ')}
+                ? "bg-[#FFEB9D] hover:brightness-95"
+                : "cursor-not-allowed bg-[#EEEEEE] text-[#9C9A9A]",
+            ].join(" ")}
           >
             섭취알림 등록하기
           </button>
         </div>
       </div>
-
       {/* PC 슬라이더 */}
       <div className="hidden px-4 md:block">
         {/* 래퍼: 화살표가 테두리 밖으로 반쯤 나오도록 overflow-visible */}
@@ -543,11 +625,15 @@ const cautionCount = cautionCombinations.length;
                 {selectedItems.map((item: SupplementItem) => (
                   <div
                     key={item.cursorId}
-                    className={`relative flex h-[250px] flex-shrink-0 snap-start flex-col items-center rounded-[22.76px] pt-[80px] ${checkedIndices.includes(item.cursorId) ? 'bg-[#EEEEEE]' : 'bg-white'}`}
+                    className={`relative flex h-[250px] flex-shrink-0 snap-start flex-col items-center rounded-[22.76px] pt-[80px] ${checkedIndices.includes(item.cursorId) ? "bg-[#EEEEEE]" : "bg-white"}`}
                     style={{ width: cardWidthCSS, minWidth: cardWidthCSS }} // ⭐ 핵심: 4등분 고정
                   >
                     <img
-                      src={checkedIndices.includes(item.cursorId) ? checkedBoxIcon : boxIcon}
+                      src={
+                        checkedIndices.includes(item.cursorId)
+                          ? checkedBoxIcon
+                          : boxIcon
+                      }
                       alt="checkbox"
                       onClick={() => handleToggleCheckbox(item.cursorId)}
                       className="absolute top-[10px] left-[18px] h-[50px] w-[50px] cursor-pointer"
@@ -559,10 +645,10 @@ const cautionCount = cautionCombinations.length;
                     <p
                       className="font-pretendard mt-1 text-center font-medium"
                       style={{
-                        fontSize: '18px',
-                        lineHeight: '100%',
-                        letterSpacing: '-0.02em',
-                        color: '#000000',
+                        fontSize: "18px",
+                        lineHeight: "100%",
+                        letterSpacing: "-0.02em",
+                        color: "#000000",
                       }}
                     >
                       {item.supplementName}
@@ -577,7 +663,7 @@ const cautionCount = cautionCombinations.length;
           {selectedItems.length > 4 && (
             <>
               <button
-                onClick={() => handleScroll('left')}
+                onClick={() => handleScroll("left")}
                 aria-label="왼쪽으로 스크롤"
                 className="absolute top-1/2 left-0 -translate-x-1/2 -translate-y-1/2"
               >
@@ -588,7 +674,7 @@ const cautionCount = cautionCombinations.length;
                 />
               </button>
               <button
-                onClick={() => handleScroll('right')}
+                onClick={() => handleScroll("right")}
                 aria-label="오른쪽으로 스크롤"
                 className="absolute top-1/2 right-0 translate-x-1/2 -translate-y-1/2"
               >
@@ -602,18 +688,21 @@ const cautionCount = cautionCombinations.length;
           )}
         </div>
       </div>
-
       {/* 모바일 슬라이더 */}
       <div className="/* 부모 컨텐츠 폭 100% */ /* iPhone 12 Pro 안전치 */ scrollbar-hide /* ← → 로 축소 */ mx-auto mt-3 w-full max-w-[358px] overflow-x-auto overflow-y-hidden rounded-[20px] border border-[#B2B2B2] bg-white px-3 py-2 py-3 md:hidden">
         <div className="flex w-max gap-3">
           {selectedItems.map((item: SupplementItem) => (
             <div
               key={item.cursorId}
-              className={`relative flex h-[135px] w-[135px] flex-shrink-0 flex-col items-center rounded-[22.76px] pt-[35px] ${checkedIndices.includes(item.cursorId) ? 'bg-[#EEEEEE]' : 'bg-white'}`}
+              className={`relative flex h-[135px] w-[135px] flex-shrink-0 flex-col items-center rounded-[22.76px] pt-[35px] ${checkedIndices.includes(item.cursorId) ? "bg-[#EEEEEE]" : "bg-white"}`}
             >
               {/* 체크박스 */}
               <img
-                src={checkedIndices.includes(item.cursorId) ? checkedBoxIcon : boxIcon}
+                src={
+                  checkedIndices.includes(item.cursorId)
+                    ? checkedBoxIcon
+                    : boxIcon
+                }
                 alt="checkbox"
                 onClick={() => handleToggleCheckbox(item.cursorId)}
                 className="absolute top-[1px] left-[110px] h-[30px] w-[30px] cursor-pointer"
@@ -631,23 +720,21 @@ const cautionCount = cautionCombinations.length;
           ))}
         </div>
       </div>
-
       {/* 모바일 섭취알림 버튼 */}
       <div className="mt-4 flex justify-center md:hidden">
         <button
-          onClick={() => {
-            if (!alarmEnabled) return; // 가드
-            navigate('/alarm/settings');
-          }}
+          onClick={handleAlarmClick}
           disabled={!alarmEnabled}
           aria-disabled={!alarmEnabled}
-          title={!alarmEnabled ? '제품을 1개만 선택해주세요' : '섭취알림 등록하기'}
+          title={
+            !alarmEnabled ? "제품을 1개만 선택해주세요" : "섭취알림 등록하기"
+          }
           className={[
-            'mt-2 flex h-[54px] w-[370px] items-center justify-center rounded-[14px] font-medium transition',
+            "mt-2 flex h-[54px] w-[370px] items-center justify-center rounded-[14px] font-medium transition",
             alarmEnabled
-              ? 'bg-[#FFEB9D] hover:brightness-95'
-              : 'cursor-not-allowed bg-[#EEEEEE] text-[#9C9A9A]',
-          ].join(' ')}
+              ? "bg-[#FFEB9D] hover:brightness-95"
+              : "cursor-not-allowed bg-[#EEEEEE] text-[#9C9A9A]",
+          ].join(" ")}
         >
           <span className="text-[20px]">섭취알림 등록하기 →</span>
         </button>
@@ -661,19 +748,19 @@ const cautionCount = cautionCombinations.length;
           {/* 탭 버튼들 */}
           <div className="relative z-10 flex justify-center">
             <div className="flex gap-80">
-              {['전체', '초과'].map((tab) => (
+              {["전체", "초과"].map((tab) => (
                 <button
                   key={tab}
-                  onClick={() => setActiveTab(tab as '전체' | '초과')}
+                  onClick={() => setActiveTab(tab as "전체" | "초과")}
                   className="font-pretendard relative mb-5 py-2 text-[30px] leading-[120%] font-semibold tracking-[-0.02em]"
                 >
                   <span
                     className={
                       activeTab === tab
-                        ? tab === '초과'
-                          ? 'text-[#E70000]'
-                          : 'text-black'
-                        : 'text-[#9C9A9A]'
+                        ? tab === "초과"
+                          ? "text-[#E70000]"
+                          : "text-black"
+                        : "text-[#9C9A9A]"
                     }
                   >
                     {tab}
@@ -689,7 +776,6 @@ const cautionCount = cautionCombinations.length;
           </div>
         </div>
       </div>
-
       {/* 모바일 버전 탭 */}
       <div className="mt-10 mb-2 md:hidden">
         <div className="relative mx-auto w-[350px]">
@@ -702,19 +788,19 @@ const cautionCount = cautionCombinations.length;
 
           {/* 탭 */}
           <div className="relative z-10 flex justify-center gap-x-30 text-center">
-            {['전체', '초과'].map((tab) => (
+            {["전체", "초과"].map((tab) => (
               <button
                 key={tab}
-                onClick={() => setActiveTab(tab as '전체' | '초과')}
+                onClick={() => setActiveTab(tab as "전체" | "초과")}
                 className="relative py-2"
               >
                 <span
                   className={`font-pretendard text-[20px] font-medium ${
                     activeTab === tab
-                      ? tab === '초과'
-                        ? 'text-[#E70000]'
-                        : 'text-black'
-                      : 'text-[#9C9A9A]'
+                      ? tab === "초과"
+                        ? "text-[#E70000]"
+                        : "text-black"
+                      : "text-[#9C9A9A]"
                   }`}
                 >
                   {tab}
@@ -729,14 +815,15 @@ const cautionCount = cautionCombinations.length;
           </div>
         </div>
       </div>
-
-      {activeTab === '초과' && (
+      {activeTab === "초과" && (
         <>
           {/* PC 버전 */}
           <div className="mt-8 hidden md:block">
             <div className="relative z-20 mx-auto w-full max-w-[1100px] px-6">
               <div className="flex h-[102px] w-full items-center justify-center rounded-[22px] bg-[#E5E5E5]">
-                <p className="font-pretendard text-center text-[32px]">적정 섭취량을 준수하세요!</p>
+                <p className="font-pretendard text-center text-[32px]">
+                  적정 섭취량을 준수하세요!
+                </p>
               </div>
             </div>
           </div>
@@ -746,9 +833,9 @@ const cautionCount = cautionCombinations.length;
             <div
               className="flex items-center justify-center rounded-[15px]"
               style={{
-                width: '350px',
-                height: '68px',
-                background: '#F4F4F4', // ← 더 진한 색상으로 변경
+                width: "350px",
+                height: "68px",
+                background: "#F4F4F4", // ← 더 진한 색상으로 변경
               }}
             >
               <p className="font-inter text-[20px] font-medium text-black">
@@ -798,12 +885,14 @@ const cautionCount = cautionCombinations.length;
                   <div
                     className="flex w-[120px] cursor-pointer items-center px-2"
                     onClick={() =>
-                      navigate(`/ingredients/${encodeURIComponent(ingredientName)}`)
+                      navigate(
+                        `/ingredients/${encodeURIComponent(ingredientName)}`
+                      )
                     }
                   >
                     <span
                       className="font-pretendard inline-block text-[15px] font-medium"
-                      style={{ lineHeight: '100%', letterSpacing: '-2%' }}
+                      style={{ lineHeight: "100%", letterSpacing: "-2%" }}
                     >
                       {ingredientName}
                     </span>
@@ -819,16 +908,25 @@ const cautionCount = cautionCombinations.length;
                   <div className="relative h-[40px] w-[200px] overflow-hidden rounded-full bg-[#EFEFEF]">
                     <div
                       className="absolute top-0 left-0 h-full rounded-full"
-                      style={{ width: `${fillPct}%`, background: over ? '#FF7E7E' : '#FFE17E' }}
+                      style={{
+                        width: `${fillPct}%`,
+                        background: over ? "#FF7E7E" : "#FFE17E",
+                      }}
                     />
                     {/* 점선(라벨과 같은 퍼센트 기준) */}
                     <div
                       className="absolute top-0 z-10 h-full border-l-2 border-dashed"
-                      style={{ left: `${REC_LINE_POS}%`, borderColor: '#000000' }}
+                      style={{
+                        left: `${REC_LINE_POS}%`,
+                        borderColor: "#000000",
+                      }}
                     />
                     <div
                       className="absolute top-0 z-10 h-full border-l-2 border-dashed"
-                      style={{ left: `${UPPER_LINE_POS}%`, borderColor: '#000000' }}
+                      style={{
+                        left: `${UPPER_LINE_POS}%`,
+                        borderColor: "#000000",
+                      }}
                     />
                   </div>
                 </div>
@@ -865,13 +963,12 @@ const cautionCount = cautionCombinations.length;
       ) : (
         <div className="mt-6 px-4 text-center text-gray-500 md:hidden">
           {ingredientResults.length === 0
-            ? '영양제를 선택해주세요.'
-            : activeTab === '초과'
-              ? '초과된 성분이 없습니다.'
-              : '데이터를 불러오는 중입니다...'}
+            ? "영양제를 선택해주세요."
+            : activeTab === "초과"
+              ? "초과된 성분이 없습니다."
+              : "데이터를 불러오는 중입니다..."}
         </div>
       )}
-
       {/* PC 섭취량 그래프 */}
       {filteredIngredients && filteredIngredients.length > 0 ? (
         <div className="hidden w-full md:block">
@@ -914,7 +1011,9 @@ const cautionCount = cautionCombinations.length;
                     <div
                       className="flex h-[48px] cursor-pointer items-center"
                       onClick={() =>
-                        navigate(`/ingredients/${encodeURIComponent(ingredientName)}`)
+                        navigate(
+                          `/ingredients/${encodeURIComponent(ingredientName)}`
+                        )
                       }
                     >
                       <span className="text-[20px] font-medium lg:text-[24px]">
@@ -935,21 +1034,21 @@ const cautionCount = cautionCombinations.length;
                           className="absolute top-0 left-0 h-full rounded-full"
                           style={{
                             width: `${fillPct}%`,
-                            background: over ? '#FF7E7E' : '#FFE17E',
+                            background: over ? "#FF7E7E" : "#FFE17E",
                           }}
                         />
                         <div
                           className="absolute top-0 z-10 h-full border-l-2 border-dashed"
                           style={{
                             left: `${REC_LINE_POS}%`,
-                            borderColor: '#000000',
+                            borderColor: "#000000",
                           }}
                         />
                         <div
                           className="absolute top-0 z-10 h-full border-l-2 border-dashed"
                           style={{
                             left: `${UPPER_LINE_POS}%`,
-                            borderColor: '#000000',
+                            borderColor: "#000000",
                           }}
                         />
                       </div>
@@ -989,25 +1088,32 @@ const cautionCount = cautionCombinations.length;
       ) : (
         <div className="mt-20 hidden flex-col items-center px-[60px] text-center text-gray-500 md:flex">
           {ingredientResults.length === 0
-            ? '영양제를 선택해주세요.'
-            : activeTab === '초과'
-              ? '초과된 성분이 없습니다.'
-              : '데이터를 불러오는 중입니다...'}
+            ? "영양제를 선택해주세요."
+            : activeTab === "초과"
+              ? "초과된 성분이 없습니다."
+              : "데이터를 불러오는 중입니다..."}
         </div>
       )}
-
       {/* ⚠️ 주의가 필요한 조합 */}
       {cautionCombinations?.length > 0 && (
         <>
           {/* 📱 모바일 - 주의 조합 */}
           <div className="mt-10 px-7 md:hidden">
-            <h2 className="text-[22px] font-semibold text-black">주의가 필요한 조합 TOP 5</h2>
-            <p className="mt-1 text-[14px] text-[#6B6B6B]">카드를 눌러서 확인해 보세요 !</p>
+            <h2 className="text-[22px] font-semibold text-black">
+              주의가 필요한 조합 TOP 5
+            </h2>
+            <p className="mt-1 text-[14px] text-[#6B6B6B]">
+              카드를 눌러서 확인해 보세요 !
+            </p>
           </div>
           <div className="hide-scrollbar overflow-x-auto px-3 md:hidden">
             <div className="mt-5 mr-4 mb-5 ml-4 flex w-max gap-[16px]">
               {cautionCombinations.map((combo: Combination) => (
-                <FlipCard key={combo.id} name={combo.name} description={combo.description} />
+                <FlipCard
+                  key={combo.id}
+                  name={combo.name}
+                  description={combo.description}
+                />
               ))}
             </div>
           </div>
@@ -1026,7 +1132,11 @@ const cautionCount = cautionCombinations.length;
               {/* 카드 래퍼: 제목과 같은 컨테이너 내부 → 시작점 일치 */}
               <div className="mt-8 mb-15 flex gap-2 lg:gap-4 xl:gap-6">
                 {cautionCombinations.map((combo: Combination) => (
-                  <FlipCard key={combo.id} name={combo.name} description={combo.description} />
+                  <FlipCard
+                    key={combo.id}
+                    name={combo.name}
+                    description={combo.description}
+                  />
                 ))}
               </div>
             </div>
@@ -1038,13 +1148,21 @@ const cautionCount = cautionCombinations.length;
         <>
           {/* 📱 모바일 - 좋은 조합 */}
           <div className="mt-10 px-7 md:hidden">
-            <h2 className="text-[22px] font-semibold text-black">궁합이 좋은 조합 TOP 5</h2>
-            <p className="mt-1 text-[14px] text-[#6B6B6B]">카드를 눌러서 확인해 보세요 !</p>
+            <h2 className="text-[22px] font-semibold text-black">
+              궁합이 좋은 조합 TOP 5
+            </h2>
+            <p className="mt-1 text-[14px] text-[#6B6B6B]">
+              카드를 눌러서 확인해 보세요 !
+            </p>
           </div>
           <div className="hide-scrollbar overflow-x-auto px-3 md:hidden">
             <div className="mt-5 mr-4 mb-15 ml-4 flex w-max gap-[16px]">
               {goodCombinations.map((combo: Combination) => (
-                <FlipCard key={combo.id} name={combo.name} description={combo.description} />
+                <FlipCard
+                  key={combo.id}
+                  name={combo.name}
+                  description={combo.description}
+                />
               ))}
             </div>
           </div>
@@ -1063,7 +1181,11 @@ const cautionCount = cautionCombinations.length;
               {/* 카드 래퍼: 제목과 같은 컨테이너 내부 */}
               <div className="mt-8 mb-20 flex gap-2 lg:gap-4 xl:gap-6">
                 {goodCombinations.map((combo: Combination) => (
-                  <FlipCard key={combo.id} name={combo.name} description={combo.description} />
+                  <FlipCard
+                    key={combo.id}
+                    name={combo.name}
+                    description={combo.description}
+                  />
                 ))}
               </div>
             </div>
@@ -1073,19 +1195,27 @@ const cautionCount = cautionCombinations.length;
       {/* ===== 공유 팝업 ===== */}
       // 하단 공유 팝업 호출부만 수정
       {shareOpen && (
-  <ShareLinkPopup
-    onClose={() => setShareOpen(false)}
-    supplementUrl={shareUrl}
-    supplementImageUrl={shareImage}
-    supplementName={shareTitle}
-    // templateId={KAKAO_TEMPLATE_ID}  // ← 커스텀 템플릿은 잠시 끄세요
-    overCount={overCount}
-    metCount={metCount}
-    cautionCount={cautionCount}
-  />
-)}
-
-
+        <ShareLinkPopup
+          onClose={() => setShareOpen(false)}
+          supplementUrl={shareUrl}
+          supplementImageUrl={shareImage}
+          supplementName={shareTitle}
+          // templateId={KAKAO_TEMPLATE_ID}  // ← 커스텀 템플릿은 잠시 끄세요
+          overCount={overCount}
+          metCount={metCount}
+          cautionCount={cautionCount}
+        />
+      )}
+      {/* ===== 알람 추가 모달 (모바일에서만 열림) ===== */}
+      {selectedItem && (
+        <AlarmAddToSearchModal
+          open={openAlarmModal}
+          onClose={() => setOpenAlarmModal(false)}
+          supplementId={selectedItem.supplementId ?? selectedItem.cursorId}
+          supplementName={selectedItem.supplementName}
+          supplementImageUrl={selectedItem.imageUrl}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📝 작업 개요

<!--무슨 작업을 했는지 요약-->

* `CombinationResultPage`의 “섭취알림 등록하기” 버튼 동작을 **반응형**으로 분기했습니다.

  * **모바일**: `AlarmAddToSearchModal` 오픈
  * **데스크탑**: `/alarm/settings/add/search?supplementId=...` 라우팅

* close #123

## ✅ 작업 내용

* `AlarmAddToSearchModal` 임포트 및 오픈 상태(`openAlarmModal`) 추가
* 체크된 제품 1개를 가져오는 `selectedItem` 파생 상태 추가
* `handleAlarmClick` 공용 핸들러 도입

  * `isMobile` 분기: 모바일 모달 / 데스크탑 라우팅
* PC/모바일 버튼 `onClick`을 `handleAlarmClick`으로 교체
* `alarmEnabled`(선택 1개) 가드 유지 및 접근성/타이틀 문자열 정리


