### PR TITLE
fix: /combination 화면 UI 이상 수정

### DIFF
--- a/src/components/combination/CombinationCardList.tsx
+++ b/src/components/combination/CombinationCardList.tsx
@@ -1,110 +1,133 @@
-import type { Combination } from "@/types/combination";
+import type { Combination } from "@/types/combination"; // 1번에서 만든 타입
 import FlipCard from "./FlipCard";
+import LoadingSkeletonCard from "./LoadingSkeletonCard";
 
 interface CombinationCardListProps {
   goodCombinations: Combination[];
-  cautionCombinations: Combination[];
+  riskyCombinations: Combination[];
+  isLoading: boolean;
+  isMobile: boolean; // 스켈레톤 크기 구분을 위해 isMobile 전달
 }
 
 export default function CombinationCardList({
   goodCombinations,
-  cautionCombinations,
+  riskyCombinations,
+  isLoading,
+  isMobile,
 }: CombinationCardListProps) {
   return (
     <>
       {/* ⚠️ 주의가 필요한 조합 */}
-      {cautionCombinations?.length > 0 && (
-        <>
-          {/* 📱 모바일 - 주의 조합 */}
-          <div className="mt-10 px-7 md:hidden">
-            <h2 className="text-[22px] font-semibold text-black">
+
+      {/* 모바일 - 주의 조합 */}
+      <div className="mt-8 px-7 md:hidden">
+        <h2 className="text-[22px] font-semibold text-black">
+          주의가 필요한 조합 TOP 5
+        </h2>
+        <p className="mt-1 text-[14px] text-[#6B6B6B]">
+          카드를 눌러서 확인해 보세요 !
+        </p>
+      </div>
+      <div className="hide-scrollbar overflow-x-auto px-3 md:hidden">
+        <div className="mt-5 mr-4 mb-5 ml-4 flex w-max gap-[16px]">
+          {isLoading
+            ? Array.from({ length: 5 }).map((_, i) => (
+                <LoadingSkeletonCard key={i} isMobile />
+              ))
+            : riskyCombinations.map((combo) => (
+                <FlipCard
+                  key={combo.id}
+                  name={combo.name}
+                  description={combo.description}
+                />
+              ))}
+        </div>
+      </div>
+
+      {/* PC - 주의 조합 (풀블리드 배경) */}
+      <div className="hidden md:block">
+        <div className="-mx-4 lg:-mx-[80px] xl:-mx-[120px] 2xl:-mx-[250px]">
+          <div className="mx-auto max-w-screen-xl px-4 lg:px-[80px] xl:px-[120px] 2xl:px-[250px]">
+            <h2 className="text-lg font-semibold whitespace-nowrap md:text-2xl">
               주의가 필요한 조합 TOP 5
             </h2>
-            <p className="mt-1 text-[14px] text-[#6B6B6B]">
+            <span className="font-Pretendard text-[16px] leading-[120%] font-semibold tracking-[-0.02em] text-[#6B6B6B] lg:text-[16px] xl:text-[18px]">
               카드를 눌러서 확인해 보세요 !
-            </p>
-          </div>
-          <div className="hide-scrollbar overflow-x-auto px-3 md:hidden">
-            <div className="mt-5 mr-4 mb-5 ml-4 flex w-max gap-[16px]">
-              {cautionCombinations.map((combo: Combination) => (
-                <FlipCard
-                  key={combo.id}
-                  name={combo.name}
-                  description={combo.description}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* 💻 PC - 주의 조합 */}
-          <section className="mt-20 hidden md:block">
-            <div className="mx-auto w-full max-w-[1050px] px-6 md:px-8">
-              <h2 className="font-Pretendard mt-3 mb-1 w-full text-left text-[24px] leading-[120%] font-bold tracking-[-0.02em] text-black lg:text-[28px] xl:text-[32px]">
-                주의가 필요한 조합 TOP 5
-              </h2>
-              <span className="font-Pretendard block text-left text-[18px] leading-[120%] font-semibold tracking-[-0.02em] text-[#6B6B6B] lg:text-[20px] xl:text-[22px]">
-                카드를 눌러서 확인해 보세요 !
-              </span>
-              <div className="mt-8 mb-15 flex gap-2 lg:gap-4 xl:gap-6">
-                {cautionCombinations.map((combo: Combination) => (
-                  <FlipCard
-                    key={combo.id}
-                    name={combo.name}
-                    description={combo.description}
-                  />
-                ))}
+            </span>
+            <div className="mt-8 mb-15 flex justify-center">
+              <div className="flex w-full gap-[15px] lg:gap-[25px] xl:gap-[25px]">
+                {isLoading
+                  ? Array.from({ length: 5 }).map((_, i) => (
+                      <LoadingSkeletonCard key={i} isMobile={false} />
+                    ))
+                  : riskyCombinations.map((combo) => (
+                      <FlipCard
+                        key={combo.id}
+                        name={combo.name}
+                        description={combo.description}
+                      />
+                    ))}
               </div>
             </div>
-          </section>
-        </>
-      )}
+          </div>
+        </div>
+      </div>
 
       {/* ===== 궁합이 좋은 조합 ===== */}
-      {goodCombinations?.length > 0 && (
-        <>
-          {/* 📱 모바일 - 좋은 조합 */}
-          <div className="mt-10 px-7 md:hidden">
-            <h2 className="text-[22px] font-semibold text-black">
-              궁합이 좋은 조합 TOP 5
-            </h2>
-            <p className="mt-1 text-[14px] text-[#6B6B6B]">
-              카드를 눌러서 확인해 보세요 !
-            </p>
-          </div>
-          <div className="hide-scrollbar overflow-x-auto px-3 md:hidden">
-            <div className="mt-5 mr-4 mb-15 ml-4 flex w-max gap-[16px]">
-              {goodCombinations.map((combo: Combination) => (
+
+      {/* 모바일 - 좋은 조합 */}
+      <div className="mt-10 px-7 md:hidden">
+        <h2 className="text-[22px] font-semibold text-black">
+          궁합이 좋은 조합 TOP 5
+        </h2>
+        <p className="mt-1 text-[14px] text-[#6B6B6B]">
+          카드를 눌러서 확인해 보세요 !
+        </p>
+      </div>
+      <div className="hide-scrollbar overflow-x-auto px-3 md:hidden">
+        <div className="mt-5 mr-4 mb-15 ml-4 flex w-max gap-[16px]">
+          {isLoading
+            ? Array.from({ length: 5 }).map((_, i) => (
+                <LoadingSkeletonCard key={i} isMobile />
+              ))
+            : goodCombinations.map((combo) => (
                 <FlipCard
                   key={combo.id}
                   name={combo.name}
                   description={combo.description}
                 />
               ))}
-            </div>
-          </div>
+        </div>
+      </div>
 
-          {/* 💻 PC - 좋은 조합 */}
-          <section className="mt-10 hidden md:block">
-            <div className="mx-auto w-full max-w-[1050px] px-6 md:px-8">
-              <h2 className="font-Pretendard mt-3 mb-1 w-full text-left text-[24px] leading-[120%] font-bold tracking-[-0.02em] text-black lg:text-[28px] xl:text-[32px]">
-                궁합이 좋은 조합 TOP 5
-              </h2>
-              <span className="font-Pretendard block text-left text-[18px] leading-[120%] font-semibold tracking-[-0.02em] text-[#6B6B6B] lg:text-[20px] xl:text-[22px]">
-                카드를 눌러서 확인해 보세요 !
-              </span>
-              <div className="mt-8 mb-20 flex gap-2 lg:gap-4 xl:gap-6">
-                {goodCombinations.map((combo: Combination) => (
-                  <FlipCard
-                    key={combo.id}
-                    name={combo.name}
-                    description={combo.description}
-                  />
-                ))}
+      {/* PC - 좋은 조합 (풀블리드 배경) */}
+      <div className="hidden md:block">
+        <div className="-mx-4 lg:-mx-[80px] xl:-mx-[120px] 2xl:-mx-[250px]">
+          <div className="mx-auto max-w-screen-xl px-4 lg:px-[80px] xl:px-[120px] 2xl:px-[250px]">
+            <h2 className="text-lg font-semibold whitespace-nowrap md:text-2xl">
+              궁합이 좋은 조합 TOP 5
+            </h2>
+            <span className="font-Pretendard text-[16px] leading-[120%] font-semibold tracking-[-0.02em] text-[#6B6B6B] lg:text-[16px] xl:text-[18px]">
+              카드를 눌러서 확인해 보세요 !
+            </span>
+            <div className="mt-8 mb-20 flex justify-center">
+              <div className="flex w-full gap-[15px] lg:gap-[25px] xl:gap-[25px]">
+                {isLoading
+                  ? Array.from({ length: 5 }).map((_, i) => (
+                      <LoadingSkeletonCard key={i} isMobile={false} />
+                    ))
+                  : goodCombinations.map((combo) => (
+                      <FlipCard
+                        key={combo.id}
+                        name={combo.name}
+                        description={combo.description}
+                      />
+                    ))}
               </div>
             </div>
-          </section>
-        </>
-      )}
+          </div>
+        </div>
+      </div>
     </>
   );
 }

--- a/src/components/combination/FlipCard.tsx
+++ b/src/components/combination/FlipCard.tsx
@@ -1,10 +1,22 @@
 import { useState } from "react";
-import flipIcon from "../../assets/flip.png";
+import flipIcon from "../../assets/flip.png"; // TODO: 경로 확인
 
 interface FlipCardProps {
   name: string;
   description: string;
 }
+
+/** PC에서 '+'가 포함된 긴 이름을 줄바꿈 처리합니다. */
+const formatIngredientNameForPC = (ingredientName: string) => {
+  if (ingredientName.includes("+")) {
+    const parts = ingredientName.split("+").map((p) => p.trim());
+    if (parts.every((p) => p.length < 7)) return ingredientName;
+    return parts
+      .map((part, idx) => (idx === 0 ? part : `\n+\n${part}`))
+      .join("");
+  }
+  return ingredientName;
+};
 
 const FlipCard: React.FC<FlipCardProps> = ({ name, description }) => {
   const [flipped, setFlipped] = useState(false);
@@ -22,8 +34,9 @@ const FlipCard: React.FC<FlipCardProps> = ({ name, description }) => {
           }`}
           style={{ transformStyle: "preserve-3d" }}
         >
+          {/* 카드 앞면 */}
           <div
-            className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-white px-[6px] py-[10px] text-center text-[18px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
+            className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-white px-[6px] py-[10px] text-center text-[18px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040] overflow-hidden" // ⬅️ overflow-hidden 추가
             style={{ backfaceVisibility: "hidden" }}
           >
             {name}
@@ -33,8 +46,9 @@ const FlipCard: React.FC<FlipCardProps> = ({ name, description }) => {
               className="absolute top-[10px] right-[10px] h-[20px] w-[20px]"
             />
           </div>
+          {/* 카드 뒷면 */}
           <div
-            className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-[#FFFBCC] px-[6px] py-[10px] text-center text-[18px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
+            className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-[#FFFBCC] px-[6px] py-[10px] text-center text-[18px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040] overflow-hidden" // ⬅️ overflow-hidden 추가
             style={{
               backfaceVisibility: "hidden",
               transform: "rotateY(180deg)",
@@ -50,7 +64,7 @@ const FlipCard: React.FC<FlipCardProps> = ({ name, description }) => {
         </div>
       </div>
 
-      {/* PC용 카드 */}
+      {/* PC 카드 */}
       <div
         className="hidden h-[165px] w-[235px] cursor-pointer md:block"
         style={{ perspective: "1000px" }}
@@ -62,19 +76,23 @@ const FlipCard: React.FC<FlipCardProps> = ({ name, description }) => {
           }`}
           style={{ transformStyle: "preserve-3d" }}
         >
+          {/* 카드 앞면 */}
           <div
-            className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-white px-[2px] py-[2px] text-center text-[20px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
+            className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-white px-[2px] py-[2px] text-center text-[20px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040] overflow-hidden" // ⬅️ overflow-hidden 추가
             style={{ backfaceVisibility: "hidden" }}
           >
-            {name}
+            <span style={{ whiteSpace: "pre-line" }}>
+              {formatIngredientNameForPC(name)}
+            </span>
             <img
               src={flipIcon}
               alt="회전 아이콘"
               className="absolute top-[10px] right-[10px] h-[20px] w-[20px]"
             />
           </div>
+          {/* 카드 뒷면 */}
           <div
-            className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-[#FFFBCC] px-[6px] py-[10px] text-center text-[20px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
+            className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-[#FFFBCC] px-[6px] py-[10px] text-center text-[20px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040] overflow-hidden" // ⬅️ overflow-hidden 추가
             style={{
               backfaceVisibility: "hidden",
               transform: "rotateY(180deg)",

--- a/src/components/combination/LoadingSkeletonCard.tsx
+++ b/src/components/combination/LoadingSkeletonCard.tsx
@@ -1,0 +1,15 @@
+interface LoadingSkeletonCardProps {
+  isMobile: boolean;
+}
+
+const LoadingSkeletonCard = ({ isMobile }: LoadingSkeletonCardProps) => (
+  <div
+    className={`${
+      isMobile ? "h-[135px] w-[150px]" : "h-[165px] w-[235px]"
+    } relative animate-pulse overflow-hidden rounded-[14px] bg-gray-200`}
+  >
+    <div className="animate-shimmer absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+  </div>
+);
+
+export default LoadingSkeletonCard;

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,17 +1,25 @@
-import { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 
-// 태블릿 세로 모드 기준점 1023px
-const useIsMobile = (breakpoint = 1023) => {
-  const [isMobile, setIsMobile] = useState<boolean>(
-    window.innerWidth < breakpoint
-  );
+const useIsMobile = (breakpoint = 768) => {
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    //
+    if (typeof window === "undefined") return false;
+    return window.innerWidth < breakpoint;
+  });
 
   useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth < breakpoint);
-    };
+    //
+    if (typeof window === "undefined") return;
+
+    const handleResize = () => setIsMobile(window.innerWidth < breakpoint);
     window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
+
+    // 컴포넌트 마운트 시점에 한 번 더 체크
+    handleResize();
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
   }, [breakpoint]);
 
   return isMobile;

--- a/src/pages/combination/CombinationPage.tsx
+++ b/src/pages/combination/CombinationPage.tsx
@@ -2,36 +2,14 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Cat from "../../assets/CatWithPointer.png";
 import Chick from "../../assets/chick.png";
-import flipIcon from "../../assets/flip.png";
+import Search from "../../assets/search.png";
 import axios from "@/lib/axios";
 import Navbar from "@/components/NavBar";
-import Search from "../../assets/search.png";
 
-// 모바일 여부 판단용 훅
-const useIsMobile = () => {
-  const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
-  useEffect(() => {
-    const handleResize = () => setIsMobile(window.innerWidth < 768);
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-  return isMobile;
-};
-
-interface Combination {
-  id: number;
-  type: "GOOD" | "CAUTION";
-  name: string;
-  description: string;
-  displayRank: number;
-}
-
-interface FlipCardProps {
-  name: string;
-  description: string;
-}
+// 분리된 모듈 Import
+import type { Combination } from "@/types/combination";
+import useIsMobile from "@/hooks/useIsMobile";
+import CombinationCardList from "@/components/combination/CombinationCardList";
 
 const CombinationPage = () => {
   const navigate = useNavigate();
@@ -85,7 +63,6 @@ const CombinationPage = () => {
     setSearchHistory(updated);
     localStorage.setItem("searchHistory", JSON.stringify(updated));
 
-    // 약간의 지연 후 페이지 이동 (로딩 상태를 보여주기 위해)
     setTimeout(() => {
       navigate(`/add-combination?query=${encodeURIComponent(trimmed)}`);
     }, 500);
@@ -97,133 +74,22 @@ const CombinationPage = () => {
     localStorage.setItem("searchHistory", JSON.stringify(updated));
   };
 
-  const formatIngredientNameForPC = (ingredientName: string) => {
-    if (ingredientName.includes("+")) {
-      const parts = ingredientName.split("+").map((p) => p.trim());
-      if (parts.every((p) => p.length < 7)) return ingredientName;
-      return parts
-        .map((part, idx) => (idx === 0 ? part : `\n+\n${part}`))
-        .join("");
-    }
-    return ingredientName;
-  };
-
-  const LoadingSkeletonCard = ({ isMobile }: { isMobile: boolean }) => (
-    <div
-      className={`${
-        isMobile ? "h-[135px] w-[150px]" : "h-[155px] w-[230px]"
-      } relative animate-pulse overflow-hidden rounded-[14px] bg-gray-200`}
-    >
-      <div className="animate-shimmer absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent" />
-    </div>
-  );
-
-  const FlipCard: React.FC<FlipCardProps> = ({ name, description }) => {
-    const [flipped, setFlipped] = useState(false);
-    return (
-      <>
-        {/* 모바일 카드 */}
-        <div
-          className="block h-[135px] w-[150px] cursor-pointer md:hidden"
-          style={{ perspective: "1000px" }}
-          onClick={() => setFlipped(!flipped)}
-        >
-          <div
-            className={`relative h-full w-full transition-transform duration-500 ${
-              flipped ? "rotate-y-180" : ""
-            }`}
-            style={{ transformStyle: "preserve-3d" }}
-          >
-            <div
-              className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-white px-[6px] py-[10px] text-center text-[18px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
-              style={{ backfaceVisibility: "hidden" }}
-            >
-              {name}
-              <img
-                src={flipIcon}
-                alt="회전 아이콘"
-                className="absolute top-[10px] right-[10px] h-[20px] w-[20px]"
-              />
-            </div>
-            <div
-              className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-[#FFFBCC] px-[6px] py-[10px] text-center text-[18px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
-              style={{
-                backfaceVisibility: "hidden",
-                transform: "rotateY(180deg)",
-              }}
-            >
-              {description}
-              <img
-                src={flipIcon}
-                alt="회전 아이콘"
-                className="absolute top-[10px] right-[10px] h-[20px] w-[20px]"
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* PC 카드 */}
-        <div
-          className="hidden h-[165px] w-[235px] cursor-pointer md:block"
-          style={{ perspective: "1000px" }}
-          onClick={() => setFlipped(!flipped)}
-        >
-          <div
-            className={`relative h-full w-full transition-transform duration-500 ${
-              flipped ? "rotate-y-180" : ""
-            }`}
-            style={{ transformStyle: "preserve-3d" }}
-          >
-            <div
-              className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-white px-[2px] py-[2px] text-center text-[20px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
-              style={{ backfaceVisibility: "hidden" }}
-            >
-              <span style={{ whiteSpace: "pre-line" }}>
-                {formatIngredientNameForPC(name)}
-              </span>
-              <img
-                src={flipIcon}
-                alt="회전 아이콘"
-                className="absolute top-[10px] right-[10px] h-[20px] w-[20px]"
-              />
-            </div>
-            <div
-              className="absolute flex h-full w-full items-center justify-center rounded-[14px] bg-[#FFFBCC] px-[6px] py-[10px] text-center text-[20px] font-medium text-[#414141] shadow-[2px_2px_12.2px_0px_#00000040]"
-              style={{
-                backfaceVisibility: "hidden",
-                transform: "rotateY(180deg)",
-              }}
-            >
-              {description}
-              <img
-                src={flipIcon}
-                alt="회전 아이콘"
-                className="absolute top-[10px] right-[10px] h-[20px] w-[20px]"
-              />
-            </div>
-          </div>
-        </div>
-      </>
-    );
-  };
-
   // 모바일에서는 전역 헤더 숨김(있으면)
   useEffect(() => {
     if (!isMobile) return;
     const headerEl = document.querySelector("header");
     if (headerEl instanceof HTMLElement) {
-      headerEl.style.display = "none";
+      // headerEl.style.display = "none"; // 원본 코드의 이 부분은 아래 Navbar 로직과 충돌할 수 있어 주석 처리
     }
     return () => {
       if (headerEl instanceof HTMLElement) {
-        headerEl.style.display = "";
+        // headerEl.style.display = "";
       }
     };
   }, [isMobile]);
 
   return (
     <div className="mx-auto max-w-screen-xl px-4 pt-2 sm:px-36 sm:pt-10">
-      {/* ✅ 모바일에서만 이 페이지의 Navbar 표시 (PC에서는 전역 Navbar만) */}
       <header className="fixed top-0 left-0 w-full z-50 bg-white shadow-sm">
         <div className="w-[90%] lg:w-[67%] mx-auto">
           <Navbar />
@@ -391,7 +257,7 @@ const CombinationPage = () => {
       {/* 고양이 일러스트 + 설명 - 모바일 */}
       <div className="relative my-20 flex justify-center md:hidden">
         <div className="relative w-[200px]">
-          <p className="font-Pretendard absolute top-[-30px] left-[-80px] w-[200px] text-start text-[18px] leading-[120%] font-medium tracking-[-0.02em] text-black">
+          <p className="font-Pretendard absolute top-[-30px] left-[-80px] w-[200px] text-start text-[18px] leading-[120%] font-medium tracking-[-0.02em] ml-[5%] text-black">
             성분 과잉 섭취 <br />
             걱정 마세요!
           </p>
@@ -401,7 +267,7 @@ const CombinationPage = () => {
             alt="병아리"
             className="absolute bottom-[18px] left-[22px] w-[45px]"
           />
-          <p className="font-Pretendard absolute right-[-90px] bottom-[-30px] w-[200px] text-right text-[18px] leading-[90%] font-medium tracking-[-0.02em] text-black">
+          <p className="font-Pretendard absolute right-[-90px] bottom-[-30px] w-[200px] text-right text-[18px] leading-[90%] font-medium tracking-[-0.02em] mr-[10%] text-black">
             성분별 총량을 한눈에!
           </p>
         </div>
@@ -410,14 +276,11 @@ const CombinationPage = () => {
       {/* 고양이 일러스트 + 설명 - PC */}
       <div className="relative my-10 flex hidden w-full justify-center md:flex">
         <div className="relative flex w-full max-w-screen-xl items-center justify-center gap-[40px]">
-          {/* 왼쪽 제목 (위쪽 정렬) */}
           <div className="flex h-full flex-col justify-start">
             <p className="font-Pretendard text-center text-[25px] leading-[120%] font-medium tracking-[-0.02em]">
               성분 과잉 섭취 걱정 마세요!
             </p>
           </div>
-
-          {/* 가운데 이미지 */}
           <div className="relative w-[200px] shrink-0">
             <img src={Cat} alt="고양이" className="w-full" />
             <img
@@ -426,8 +289,6 @@ const CombinationPage = () => {
               className="absolute bottom-[18px] left-[22px] w-[45px]"
             />
           </div>
-
-          {/* 오른쪽 제목 (아래쪽 정렬) */}
           <div className="flex h-full flex-col justify-end">
             <p className="font-Pretendard text-center text-[25px] leading-[120%] font-medium tracking-[-0.02em]">
               성분별 총량을 한눈에!
@@ -438,172 +299,15 @@ const CombinationPage = () => {
 
       {/* 구분선 (모바일) */}
       <div>
-        <div className="mx-auto block h-[0.5px] w-[390px] bg-[#B2B2B2] md:hidden" />
+        <div className="mx-auto block h-[0.5px] w-full bg-[#B2B2B2] md:hidden" />
       </div>
 
-      {/* 주의가 필요한 조합 - 모바일 */}
-      <div className="mt-8 px-7 md:hidden">
-        <h2
-          style={{
-            width: "390px",
-            height: "26px",
-            fontFamily: "Pretendard",
-            fontWeight: 600,
-            fontSize: "22px",
-            lineHeight: "120%",
-            letterSpacing: "-0.02em",
-            color: "#000000",
-          }}
-        >
-          주의가 필요한 조합 TOP 5
-        </h2>
-        <p
-          style={{
-            width: "200px",
-            height: "17px",
-            fontFamily: "Pretendard",
-            fontWeight: 600,
-            fontSize: "14px",
-            lineHeight: "120%",
-            letterSpacing: "-0.02em",
-            color: "#6B6B6B",
-            marginTop: "6px",
-          }}
-        >
-          카드를 눌러서 확인해 보세요 !
-        </p>
-      </div>
-
-      {/* 조합 카드들 - 모바일 (주의) */}
-      <div className="hide-scrollbar overflow-x-auto px-3 md:hidden">
-        <div className="mt-5 mr-4 mb-5 ml-4 flex w-max gap-[16px]">
-          {isLoading
-            ? Array.from({ length: 5 }).map((_, i) => (
-                <LoadingSkeletonCard key={i} isMobile />
-              ))
-            : riskyCombinations.map((combo) => (
-                <FlipCard
-                  key={combo.id}
-                  name={combo.name}
-                  description={combo.description}
-                />
-              ))}
-        </div>
-      </div>
-
-      {/* 주의가 필요한 조합 - PC (풀블리드 배경) */}
-      <div className="hidden md:block">
-        {/* 배경을 좌우 패딩까지 확장 */}
-        <div className="-mx-4 lg:-mx-[80px] xl:-mx-[120px] 2xl:-mx-[250px]">
-          {/* 안쪽은 다시 동일한 패딩으로 정렬 복구 */}
-          <div className="mx-auto max-w-screen-xl px-4 lg:px-[80px] xl:px-[120px] 2xl:px-[250px]">
-            <h2 className="text-lg font-semibold whitespace-nowrap md:text-2xl">
-              주의가 필요한 조합 TOP 5
-            </h2>
-            <span className="font-Pretendard text-[16px] leading-[120%] font-semibold tracking-[-0.02em] text-[#6B6B6B] lg:text-[16px] xl:text-[18px]">
-              카드를 눌러서 확인해 보세요 !
-            </span>
-
-            <div className="mt-8 mb-15 flex justify-center">
-              <div className="flex w-full gap-[15px] lg:gap-[25px] xl:gap-[25px]">
-                {isLoading
-                  ? Array.from({ length: 5 }).map((_, i) => (
-                      <LoadingSkeletonCard key={i} isMobile={false} />
-                    ))
-                  : riskyCombinations.map((combo) => (
-                      <FlipCard
-                        key={combo.id}
-                        name={combo.name}
-                        description={combo.description}
-                      />
-                    ))}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* 궁합이 좋은 조합 - 모바일 */}
-      <div className="mt-10 px-7 md:hidden">
-        <h2
-          style={{
-            width: "390px",
-            height: "26px",
-            fontFamily: "Pretendard",
-            fontWeight: 600,
-            fontSize: "22px",
-            lineHeight: "120%",
-            letterSpacing: "-0.02em",
-            color: "#000000",
-          }}
-        >
-          궁합이 좋은 조합 TOP 5
-        </h2>
-        <p
-          style={{
-            width: "300px",
-            height: "17px",
-            fontFamily: "Pretendard",
-            fontWeight: 600,
-            fontSize: "14px",
-            lineHeight: "120%",
-            letterSpacing: "-0.02em",
-            color: "#6B6B6B",
-            marginTop: "6px",
-          }}
-        >
-          카드를 눌러서 확인해 보세요 !
-        </p>
-      </div>
-
-      {/* 조합 카드들 - 모바일 (좋음) */}
-      <div className="hide-scrollbar overflow-x-auto px-3 md:hidden">
-        <div className="mt-5 mr-4 mb-15 ml-4 flex w-max gap-[16px]">
-          {isLoading
-            ? Array.from({ length: 5 }).map((_, i) => (
-                <LoadingSkeletonCard key={i} isMobile />
-              ))
-            : goodCombinations.map((combo) => (
-                <FlipCard
-                  key={combo.id}
-                  name={combo.name}
-                  description={combo.description}
-                />
-              ))}
-        </div>
-      </div>
-
-      {/* 궁합이 좋은 조합 - PC (풀블리드 배경) */}
-      <div className="hidden md:block">
-        {/* 배경을 좌우 패딩까지 확장 */}
-        <div className="-mx-4 lg:-mx-[80px] xl:-mx-[120px] 2xl:-mx-[250px]">
-          {/* 안쪽은 다시 동일한 패딩으로 정렬 복구 */}
-          <div className="mx-auto max-w-screen-xl px-4 lg:px-[80px] xl:px-[120px] 2xl:px-[250px]">
-            <h2 className="text-lg font-semibold whitespace-nowrap md:text-2xl">
-              궁합이 좋은 조합 TOP 5
-            </h2>
-            <span className="font-Pretendard text-[16px] leading-[120%] font-semibold tracking-[-0.02em] text-[#6B6B6B] lg:text-[16px] xl:text-[18px]">
-              카드를 눌러서 확인해 보세요 !
-            </span>
-
-            <div className="mt-8 mb-20 flex justify-center">
-              <div className="flex w-full gap-[15px] lg:gap-[25px] xl:gap-[25px]">
-                {isLoading
-                  ? Array.from({ length: 5 }).map((_, i) => (
-                      <LoadingSkeletonCard key={i} isMobile={false} />
-                    ))
-                  : goodCombinations.map((combo) => (
-                      <FlipCard
-                        key={combo.id}
-                        name={combo.name}
-                        description={combo.description}
-                      />
-                    ))}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <CombinationCardList
+        goodCombinations={goodCombinations}
+        riskyCombinations={riskyCombinations}
+        isLoading={isLoading}
+        isMobile={isMobile}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## 📝 작업 개요

- `CombinationPage` 및 `CombinationResultPage`의 컴포넌트를 분리하여 모듈화 작업을 진행했습니다.
- 모바일 뷰에서 발생하던 가로 스크롤 및 카드 콘텐츠 오버플로우 문제를 해결했습니다.

## ✅ 작업 내용

### 1. 리팩터링 (모듈화)

- **공용 컴포넌트 분리**:
    - `FlipCard`: 조합 추천 카드를 공용 컴포넌트로 분리했습니다.
    - `CombinationCardList`: 조합 리스트 섹션(주의/좋은 조합)을 분리했습니다.
    - `ProductSlider`: (결과 페이지) 선택된 제품 슬라이더를 분리했습니다.
    - `IngredientGaugeList`: (결과 페이지) 성분 게이지 리스트를 분리했습니다.
- **유틸리티 및 훅 분리**:
    - `types/combination.ts`: 공통 타입을 분리했습니다.
    - `utils/gauge.ts`, `utils/kakao.ts` 등: 페이지별 비즈니스 로직을 유틸 함수로 분리했습니다.
    - `hooks/useIsMobile.ts`: 모바일 반응형 훅을 분리했습니다.

### 2. 레이아웃 버그 수정

- **페이지 전체 가로 스크롤 문제 해결**:
    - 모바일 뷰에서 `w-[390px]` 고정 폭을 사용하던 구분선을 `w-11/12` (또는 `w-full`)로 수정하여 작은 기기에서 가로 스크롤이 생기던 문제를 해결했습니다.
    - 고양이 일러스트의 텍스트가 절대 좌표(`right-[-90px]`)로 인해 화면 밖으로 삐져나가던 문제를 수정했습니다.
- **`FlipCard` 콘텐츠 오버플로우 수정**:
    - `FlipCard`의 `description` 텍스트가 고정 높이(`h-[135px]`) 밖으로 삐져나오는 문제를 해결했습니다.
    - 카드의 섀도우(그림자)는 유지하면서 넘치는 텍스트만 잘리도록, 카드 **안쪽** 앞/뒷면 `div`에 `overflow-hidden`을 적용했습니다.