### PR TITLE
fix: 브라우저 알림 권한 모달

### DIFF
--- a/src/pages/alarm/AlarmPage.tsx
+++ b/src/pages/alarm/AlarmPage.tsx
@@ -1,70 +1,58 @@
-// import { useEffect, useRef, useState, useCallback } from "react";
-// import { useMediaQuery } from "react-responsive";
-
-// import MobileAlarmPage from "./MobileAlarmPage";
-// import DesktopAlarmPage from "./DesktopAlarmPage";
-
-// const AlarmPage = () => {
-//   const isMobile = useMediaQuery({ maxWidth: 639 });
-//   const today = new Date();
-
-//   const [year, setYear] = useState(today.getFullYear());
-//   const [month, setMonth] = useState(today.getMonth());
-//   const [checkedIds, setCheckedIds] = useState<string[]>([]);
-//   const initRef = useRef(false);
-
-//   const toggleChecked = (id: string) => {
-//     setCheckedIds((prev) =>
-//       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-//     );
-//   };
-
-//   const getDaysInMonth = (year: number, month: number) =>
-//     new Date(year, month + 1, 0).getDate();
-
-//   const needPermissionBanner =
-//     typeof Notification !== "undefined" &&
-//     Notification.permission !== "granted";
-
-//   const perm =
-//     typeof Notification !== "undefined" ? Notification.permission : "default";
-
-//   return (
-//     <div className="relative">
-//       {isMobile ? (
-//         <MobileAlarmPage
-//           year={year}
-//           month={month}
-//           today={today}
-//           setYear={setYear}
-//           setMonth={setMonth}
-//           checkedIds={checkedIds}
-//           toggleChecked={toggleChecked}
-//           getDaysInMonth={getDaysInMonth}
-//         />
-//       ) : (
-//         <DesktopAlarmPage
-//           year={year}
-//           month={month}
-//           today={today}
-//           setYear={setYear}
-//           setMonth={setMonth}
-//           toggleChecked={toggleChecked}
-//           getDaysInMonth={getDaysInMonth}
-//         />
-//       )}
-//     </div>
-//   );
-// };
-
-// export default AlarmPage;
-// src/pages/alarm/AlarmPage.tsx
 import { useEffect, useRef, useState, useCallback } from "react";
 import { useMediaQuery } from "react-responsive";
 import MobileAlarmPage from "./MobileAlarmPage";
 import DesktopAlarmPage from "./DesktopAlarmPage";
 
 import { enableWebPush } from "@/lib/push";
+interface NotificationPermissionModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isLoading: boolean;
+}
+
+function NotificationPermissionModal({
+  open,
+  onClose,
+  onConfirm,
+  isLoading,
+}: NotificationPermissionModalProps) {
+  if (!open) return null;
+
+  return (
+    // 오버레이
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      {/* 모달 컨텐츠 */}
+      <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-lg">
+        <h3 className="text-center text-lg font-medium text-black">알림켜기</h3>
+
+        {/* 이미지와 동일한 텍스트 및 줄바꿈 적용 */}
+        <p className="my-4 text-center text-sm text-[#9C9A9A]">
+          브라우저를 알림을 켜면
+          <br />
+          설정한 시간에 복용알림을 받을 수 있어요
+        </p>
+
+        {/* 버튼 */}
+        <div className="flex gap-3">
+          <button
+            onClick={onClose}
+            className="flex-1 rounded-lg bg-[#EEEEEE] py-3 font-semibold text-[#6B6B6B] transition hover:bg-gray-300"
+          >
+            취소
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="flex-1 rounded-lg bg-[#FFEB9D] py-3 font-semibold text-black transition hover:brightness-95 disabled:opacity-50"
+          >
+            {isLoading ? "설정 중..." : "확인"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 const AlarmPage = () => {
   const isMobile = useMediaQuery({ maxWidth: 639 });
@@ -75,8 +63,10 @@ const AlarmPage = () => {
   const [checkedIds, setCheckedIds] = useState<string[]>([]);
   const initRef = useRef(false);
 
-  // 🔽 추가: 버튼 로딩 상태
   const [enabling, setEnabling] = useState(false);
+
+  // 🔽 추가: 모달이 닫혔는지(취소 눌렀는지) 상태
+  const [modalDismissed, setModalDismissed] = useState(false);
 
   const toggleChecked = (id: string) => {
     setCheckedIds((prev) =>
@@ -87,16 +77,15 @@ const AlarmPage = () => {
   const getDaysInMonth = (year: number, month: number) =>
     new Date(year, month + 1, 0).getDate();
 
-  const needPermissionBanner =
+  // "알림 권한이 '허용'이 아닌 경우"에 true
+  const needPermission =
     typeof Notification !== "undefined" &&
     Notification.permission !== "granted";
 
-  // 🔽 추가: 버튼 클릭 핸들러
   const onEnablePush = useCallback(async () => {
     setEnabling(true);
     const res = await enableWebPush({
       onMessage: (p) => {
-        // 포그라운드 수신 시 원하는 UX (토스트/배지 등)
         console.log("[PUSH][FG] payload:", p);
       },
     });
@@ -113,25 +102,13 @@ const AlarmPage = () => {
       };
       alert(msg[res.reason] ?? msg.unknown);
     }
-    // 성공이면 Notification.permission 이 'granted'로 바뀌면서 배너는 자동으로 사라짐
+    // 성공 시: Notification.permission이 'granted'가 됨
+    // -> needPermission이 false가 됨
+    // -> 모달이 자동으로 닫힘 (open 조건이 false가 되므로)
   }, []);
 
   return (
     <div className="relative">
-      {/* 🔽 상단 배너: 권한 미허용일 때만 노출 */}
-      {needPermissionBanner && (
-        <div className="mb-3 rounded-lg border px-3 py-2 text-sm flex items-center justify-between bg-white">
-          <span>브라우저 알림을 켜면 설정한 시간에 복용 알림을 받아요.</span>
-          <button
-            className="ml-3 rounded-md border px-3 py-1 text-sm"
-            disabled={enabling}
-            onClick={onEnablePush}
-          >
-            {enabling ? "설정 중..." : "알림 켜기"}
-          </button>
-        </div>
-      )}
-
       {isMobile ? (
         <MobileAlarmPage
           year={year}
@@ -154,6 +131,15 @@ const AlarmPage = () => {
           getDaysInMonth={getDaysInMonth}
         />
       )}
+
+      {/* 모달 렌더링  */}
+      <NotificationPermissionModal
+        // (알림 권한이 없고) && (유저가 '취소'를 누르지 않았을 때)
+        open={needPermission && !modalDismissed}
+        isLoading={enabling}
+        onConfirm={onEnablePush}
+        onClose={() => setModalDismissed(true)} // '취소' 누르면 모달 닫기
+      />
     </div>
   );
 };


### PR DESCRIPTION
## 📝 작업 개요

- 알람 페이지(`AlarmPage`) 진입 시, 브라우저 알림 권한을 요청하는 UI를 기존 상단 배너에서 팝업 모달 형태로 변경합니다.

## ✅ 작업 내용

- `AlarmPage.tsx` 상단에 텍스트로 표시되던 `needPermissionBanner` 관련 UI와 로직을 제거했습니다.
- 디자인 시안에 맞춰 `NotificationPermissionModal` 컴포넌트를 `AlarmPage.tsx` 파일 내에 새로 추가했습니다.
- `Notification.permission` 상태가 'granted'가 아닐 경우, 이 모달이 표시되도록 로직을 수정했습니다.
- 사용자가 '취소' 버튼을 누를 경우, `modalDismissed` 상태를 true로 변경하여 모달이 다시 뜨지 않도록 처리했습니다.
- '확인' 버튼 클릭 시 `onEnablePush` 함수가, '취소' 클릭 시 `onClose` 핸들러가 호출되도록 연결했습니다.

## 📸 스크린샷 (선택)
<img width="701" height="436" alt="image" src="https://github.com/user-attachments/assets/5686da21-17d0-4e20-81dd-2699bf525f9e" />
