### PR TITLE
fix: 알림 중복 수정

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -20,7 +20,6 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 
-// ✅ 지연 초기화(한 번만 생성)
 let _messagingReady: Promise<Messaging | null> | null = null;
 function ensureMessaging(): Promise<Messaging | null> {
   if (!_messagingReady) {

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -20,7 +20,6 @@ try {
   console.debug("[FCM] localStorage read fail (private mode?)");
 }
 
-/** ✅ 서버에 정확히 { fcmToken, deviceType: "WEB" } 형태로 업서트 */
 async function upsertFcmToken(token: string) {
   console.debug("[FCM] upsertFcmToken START", token?.slice(0, 8), "...");
   try {

--- a/src/pages/alarm/AlarmPage.tsx
+++ b/src/pages/alarm/AlarmPage.tsx
@@ -84,11 +84,8 @@ const AlarmPage = () => {
 
   const onEnablePush = useCallback(async () => {
     setEnabling(true);
-    const res = await enableWebPush({
-      onMessage: (p) => {
-        console.log("[PUSH][FG] payload:", p);
-      },
-    });
+
+    const res = await enableWebPush();
     setEnabling(false);
 
     if (!res.ok) {

--- a/src/types/alarm.ts
+++ b/src/types/alarm.ts
@@ -12,7 +12,6 @@ export interface Supplement {
   supplementId?: number;
   supplementName: string;
   supplementImageUrl?: string;
-  // ✅ 더 안전하게: DayOfWeek로 명확히 타이핑
   daysOfWeek: DayOfWeek[];
   times: string[];
   isTaken: boolean;


### PR DESCRIPTION
## 📝 작업 개요

- 앱이 포그라운드(활성) 상태일 때 푸시 알림이 2개씩 중복으로 뜨는 현상을 수정합니다.

## ✅ 작업 내용

- **원인:**
  `App.tsx`의 전역 FCM 리스너(`onForegroundMessage`)와 `AlarmPage.tsx`의 `onEnablePush` 함수 내 `onMessage` 리스너가 중복으로 등록되어 있었습니다. 이로 인해 포그라운드 메시지 1개가 2개의 핸들러에 의해 처리되어 알림이 2번 발생했습니다.

- **수정:**
  `AlarmPage.tsx`의 `enableWebPush` 함수 호출 시 `onMessage` 옵션을 제거했습니다. 이제 `App.tsx`의 전역 리스너만 포그라운드 알림을 처리합니다.