### PR TITLE
fix: 알림 중복 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,6 +161,9 @@ function App() {
   useEffect(() => {
     let mounted = true;
 
+    // 1. 리스너 해제 함수를 저장할 변수
+    let unsubscribe: (() => void) | undefined;
+
     (async () => {
       try {
         await registerServiceWorker();
@@ -169,10 +172,13 @@ function App() {
           await syncFcmTokenAfterLoginSilently().catch(() => {});
         }
 
-        onForegroundMessage((p) => {
+        // 2. onForegroundMessage가 Promise를 반환하므로 await
+        // Promise가 반환한 '해제 함수'를 변수에 저장
+        unsubscribe = await onForegroundMessage((p) => {
           const title = p?.notification?.title ?? p?.data?.title ?? "VitaCheck";
           const body = p?.notification?.body ?? p?.data?.body ?? "";
           console.log("[FCM] foreground:", title, body);
+          // (알림 띄우는 로직...)
         });
       } catch (e) {
         console.warn("[FCM] init error:", e);
@@ -180,7 +186,13 @@ function App() {
     })();
 
     return () => {
+      // 3. Cleanup 함수
       mounted = false;
+
+      // 4. 컴포넌트가 언마운트될 때 리스너를 명시적으로 해제
+      if (unsubscribe) {
+        unsubscribe();
+      }
     };
   }, []);
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -7,6 +7,7 @@ import {
   isSupported,
   deleteToken,
   type Messaging,
+  type Unsubscribe,
 } from "firebase/messaging";
 
 const firebaseConfig = {
@@ -84,10 +85,24 @@ export async function getFcmToken(): Promise<string | null> {
 }
 
 /** 포그라운드 수신 */
+// export function onForegroundMessage(cb: (p: any) => void) {
+//   ensureMessaging().then((m) => {
+//     if (!m) return;
+//     onMessage(m, (payload) => {
+//       console.log("[FCM] onMessage payload", payload);
+//       cb(payload);
+//     });
+//   });
+// }
+
+/** 포그라운드 수신 */
 export function onForegroundMessage(cb: (p: any) => void) {
-  ensureMessaging().then((m) => {
+  // 🔽 2. 이 함수가 Promise<Unsubscribe | void>를 반환하도록 수정합니다.
+  return ensureMessaging().then((m) => {
     if (!m) return;
-    onMessage(m, (payload) => {
+
+    // 🔽 3. onMessage가 반환하는 unsubscribe 함수를 여기서 return합니다.
+    return onMessage(m, (payload) => {
       console.log("[FCM] onMessage payload", payload);
       cb(payload);
     });

--- a/src/pages/alarm/AlarmPage.tsx
+++ b/src/pages/alarm/AlarmPage.tsx
@@ -101,7 +101,7 @@ const AlarmPage = () => {
     }
     // 성공 시: Notification.permission이 'granted'가 됨
     // -> needPermission이 false가 됨
-    // -> 모달이 자동으로 닫힘 (open 조건이 false가 되므로)
+    // -> 모달이 자동으로 닫힘 (open 조건이 false가 되니까)
   }, []);
 
   return (


### PR DESCRIPTION
## 📝 작업 개요

- React 18의 `<StrictMode>`(엄격 모드) 환경에서 FCM 포그라운드 알림이 2번 중복으로 수신되는 문제를 해결합니다.

## ✅ 작업 내용

- **문제 원인:**
  개발 환경에서 `<StrictMode>`가 `App.tsx`의 `useEffect`를 **[마운트 → 언마운트 → 재마운트]**시켰습니다. 이때, `useEffect`의 `cleanup` 함수(return)에 `onForegroundMessage` 리스너를 해제(unsubscribe)하는 로직이 없어, 리스너가 중복으로 등록되어 알림이 2번 호출되었습니다.

- **수정 사항:**
  1.  **`src/lib/firebase.ts` 수정:**
      - `onForegroundMessage` 함수가 `onMessage`가 반환하는 **'리스너 해제(unsubscribe) 함수'**를 `Promise`를 통해 반환하도록 수정했습니다.
  2.  **`src/App.tsx` 수정:**
      - `useEffect` 내에서 `await onForegroundMessage(...)`를 통해 리스너 해제 함수를 `unsubscribe` 변수에 저장했습니다.
      - `useEffect`의 `cleanup` 함수(return 구문)에서 `unsubscribe()`를 호출하여, 컴포넌트 언마운트 시 리스너가 깨끗하게 정리되도록 수정했습니다.